### PR TITLE
Removing class="sidebar" attribute, as only data-type is needed

### DIFF
--- a/htmlbook-autogen/block_sidebar.html.erb
+++ b/htmlbook-autogen/block_sidebar.html.erb
@@ -1,4 +1,4 @@
-<%#encoding:UTF-8%><aside<%= @id && %( id="#{@id}") %> data-type="sidebar" class="sidebar<%= attr?('role') ? %( #{attr 'role'}) : nil %>">
-<h5><%= title %></h5>
-<%= content %>
+<%#encoding:UTF-8%><aside<%= @id && %( id="#{@id}") %> data-type="sidebar"<%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>
+<h5><%= title %></h5><%= 
+content %>
 </aside>


### PR DESCRIPTION
Prevents issue where CKEditor suppresses content with class="sidebar".
