### PR TITLE
Removing autogeneration of em dash in quote attributions

### DIFF
--- a/htmlbook-autogen/block_quote.html.erb
+++ b/htmlbook-autogen/block_quote.html.erb
@@ -5,5 +5,5 @@ if attr? :citetitle %>
 <cite><%= attr :citetitle %></cite><% end %><%
 if attr? :attribution %><% if attr? :citetitle %>
 <% end %><%=
-"&#8212; #{attr :attribution}" %><% end %></p>
+"#{attr :attribution}" %><% end %></p>
 <% end %></blockquote>

--- a/htmlbook/block_quote.html.erb
+++ b/htmlbook/block_quote.html.erb
@@ -5,5 +5,5 @@ if attr? :citetitle %>
 <cite><%= attr :citetitle %></cite><% end %><%
 if attr? :attribution %><% if attr? :citetitle %>
 <% end %><%=
-"&#8212; #{attr :attribution}" %><% end %></p>
+"#{attr :attribution}" %><% end %></p>
 <% end %></blockquote>


### PR DESCRIPTION
Will handle via CSS instead
