### PR TITLE
Handling for [introduction]

### DIFF
--- a/htmlbook-autogen/section.html.erb
+++ b/htmlbook-autogen/section.html.erb
@@ -22,6 +22,11 @@ title_html = %(#{sectnum} #{title_html}) if !@special && (attr? 'numbered') && @
 <%= %(<h#{@level}) %>><%= title %><%= %(</h#{@level}>) %>
 
 <%= content %>
+<% elsif sectname == 'introduction'%>
+<section data-type="introduction"<%= attr?('id') ? %( id="#{attr 'id'}") : nil %><%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>
+<%= %(<h#{@level}) %>><%= title %><%= %(</h#{@level}>) %>
+
+<%= content %>
 </section>
 <% elsif sectname == 'appendix' and role == 'bibliography' %>
 <section data-type="bibliography"<%= attr?('id') ? %( id="#{attr 'id'}") : nil %><%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>

--- a/htmlbook/section.html.erb
+++ b/htmlbook/section.html.erb
@@ -22,6 +22,11 @@ title_html = %(#{sectnum} #{title_html}) if !@special && (attr? 'numbered') && @
 <%= %(<h#{@level}) %>><%= title %><%= %(</h#{@level}>) %>
 
 <%= content %>
+<% elsif sectname == 'introduction'%>
+<section data-type="introduction"<%= attr?('id') ? %( id="#{attr 'id'}") : nil %><%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>
+<%= %(<h#{@level}) %>><%= title %><%= %(</h#{@level}>) %>
+
+<%= content %>
 </section>
 <% elsif sectname == 'appendix' and role == 'bibliography' %>
 <section data-type="bibliography"<%= attr?('id') ? %( id="#{attr 'id'}") : nil %><%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>

--- a/spec/htmlbook_spec.rb
+++ b/spec/htmlbook_spec.rb
@@ -43,6 +43,13 @@ describe "HTMLBook Templates" do
                 html.xpath("//section[@data-type='foreword']/h1").text.should == "Foreword"
         end
 
+        it "should convert Introduction titles" do
+            html = Nokogiri::HTML(convert("
+[introduction]
+== This is the Introduction"))
+                html.xpath("//section[@data-type='introduction']/h1").text.should == "This is the Introduction"
+        end
+
         it "should convert index titles" do
             html = Nokogiri::HTML(convert("== Index"))
                 html.xpath("//section[@data-type='index']/h1").text.should == "Index"


### PR DESCRIPTION
Hi @sarahs,

This pull request adds handling to convert sections tagged as "introduction" (not a core part of AsciiDoc vocab, but I think it's worth adding support for this customization):

````
[introduction]
== This is an Introduction

Some text here
````

To HTMLBook as follows:

````
<section data-type="introduction">
  <h1>This is an Introduction</h1>
  <p>Some text here</p>
</section>
````

Could you please review and let me know if this looks good to merge?

Thanks,
Sanders