### PR TITLE
Adding handling to always add p elements within admonitions

### DIFF
--- a/htmlbook-autogen/block_admonition.html.erb
+++ b/htmlbook-autogen/block_admonition.html.erb
@@ -1,3 +1,5 @@
-<%#encoding:UTF-8%><div data-type="<%= attr 'name' %>"<%= attr?('role') ? %( class="#{attr 'role'}") : nil %><%= attr?('id') ? %( id="#{attr 'id'}") : nil %>><%= title? ? %(<h1>#{title}</h1>) : nil %><%= 
-content.chomp %>
+<%#encoding:UTF-8%><div data-type="<%= attr 'name' %>"<%= attr?('role') ? %( class="#{attr 'role'}") : nil %><%= attr?('id') ? %( id="#{attr 'id'}") : nil %>><%= title? ? %(<h1>#{title}</h1>) : nil %><% if @content_model.to_s == 'compound' %><%= 
+content.chomp %><% else %>
+<p><%= content %></p><% 
+end %>
 </div>

--- a/htmlbook/block_admonition.html.erb
+++ b/htmlbook/block_admonition.html.erb
@@ -1,3 +1,5 @@
-<%#encoding:UTF-8%><div data-type="<%= attr 'name' %>"<%= attr?('role') ? %( class="#{attr 'role'}") : nil %><%= attr?('id') ? %( id="#{attr 'id'}") : nil %>><%= title? ? %(<h1>#{title}</h1>) : nil %><%= 
-content.chomp %>
+<%#encoding:UTF-8%><div data-type="<%= attr 'name' %>"<%= attr?('role') ? %( class="#{attr 'role'}") : nil %><%= attr?('id') ? %( id="#{attr 'id'}") : nil %>><%= title? ? %(<h1>#{title}</h1>) : nil %><% if @content_model.to_s == 'compound' %><%= 
+content.chomp %><% else %>
+<p><%= content %></p><% 
+end %>
 </div>

--- a/spec/htmlbook_spec.rb
+++ b/spec/htmlbook_spec.rb
@@ -76,14 +76,34 @@ describe "HTMLBook Templates" do
 	end
 
 	# Tests block_admonition template
-	it "should convert notes" do
+	it "should convert notes with admonition block markup" do
 		html = Nokogiri::HTML(convert("
 [NOTE]
 ====
-Here is some text inside a note.
+Here is a note with block markup.
+
+Here is a second paragraph.
 ====
 "))
-		html.xpath("//div[@data-type='note']/p").text.should == "Here is some text inside a note."
+		html.xpath("//div[@data-type='note']/p[1]").text.should == "Here is a note with block markup."
+		html.xpath("//div[@data-type='note']/p[2]").text.should == "Here is a second paragraph."
+	end
+
+	# Tests block_admonition template alternate markup
+	it "should convert notes with admonition paragraph markup" do
+		html = Nokogiri::HTML(convert("
+[NOTE]
+Here is a note with paragraph markup.
+"))
+		html.xpath("//div[@data-type='note']/p").text.should == "Here is a note with paragraph markup."
+	end
+
+	# Tests block_admonition template second alternate markup
+	it "should convert notes with alternate admonition paragraph markup" do
+		html = Nokogiri::HTML(convert("
+NOTE: Here is a note with alternate paragraph markup.
+"))
+		html.xpath("//div[@data-type='note']/p").text.should == "Here is a note with alternate paragraph markup."
 	end
 
 


### PR DESCRIPTION
regardless of whether block or paragraph markup is used in source

Resolves #81.