### PR TITLE
Adding handling to support part styling of == headings.

### DIFF
--- a/htmlbook-autogen/section.html.erb
+++ b/htmlbook-autogen/section.html.erb
@@ -9,9 +9,14 @@
 title_html = %(<a name="#{@id}" class="anchor" href="#{@id}">#{title_html}</a>) if (attr? 'anchors')
 title_html = %(#{sectnum} #{title_html}) if !@special && (attr? 'numbered') && @level < 4
 %>
-
 <% if @level == 1 %>
-<% if sectname == 'preface' and title == 'Foreword' %>
+<% if sectname == 'part' %>
+<div data-type="part"<%= attr?('id') ? %( id="#{attr 'id'}") : nil %><%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>
+<%= %(<h1) %>><%= title %><%= %(</h1>) %>
+
+<%= content %>
+</div>
+<% elsif sectname == 'preface' and title == 'Foreword' %>
 <section data-type="foreword"<%= attr?('id') ? %( id="#{attr 'id'}") : nil %><%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>
 <%= %(<h#{@level}) %>><%= title %><%= %(</h#{@level}>) %>
 

--- a/htmlbook-autogen/section.html.erb
+++ b/htmlbook-autogen/section.html.erb
@@ -9,6 +9,7 @@
 title_html = %(<a name="#{@id}" class="anchor" href="#{@id}">#{title_html}</a>) if (attr? 'anchors')
 title_html = %(#{sectnum} #{title_html}) if !@special && (attr? 'numbered') && @level < 4
 %>
+
 <% if @level == 1 %>
 <% if sectname == 'part' %>
 <div data-type="part"<%= attr?('id') ? %( id="#{attr 'id'}") : nil %><%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>

--- a/htmlbook/section.html.erb
+++ b/htmlbook/section.html.erb
@@ -9,9 +9,14 @@
 title_html = %(<a name="#{@id}" class="anchor" href="#{@id}">#{title_html}</a>) if (attr? 'anchors')
 title_html = %(#{sectnum} #{title_html}) if !@special && (attr? 'numbered') && @level < 4
 %>
-
 <% if @level == 1 %>
-<% if sectname == 'preface' and title == 'Foreword' %>
+<% if sectname == 'part' %>
+<div data-type="part"<%= attr?('id') ? %( id="#{attr 'id'}") : nil %><%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>
+<%= %(<h1) %>><%= title %><%= %(</h1>) %>
+
+<%= content %>
+</div>
+<% elsif sectname == 'preface' and title == 'Foreword' %>
 <section data-type="foreword"<%= attr?('id') ? %( id="#{attr 'id'}") : nil %><%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>
 <%= %(<h#{@level}) %>><%= title %><%= %(</h#{@level}>) %>
 

--- a/htmlbook/section.html.erb
+++ b/htmlbook/section.html.erb
@@ -9,6 +9,7 @@
 title_html = %(<a name="#{@id}" class="anchor" href="#{@id}">#{title_html}</a>) if (attr? 'anchors')
 title_html = %(#{sectnum} #{title_html}) if !@special && (attr? 'numbered') && @level < 4
 %>
+
 <% if @level == 1 %>
 <% if sectname == 'part' %>
 <div data-type="part"<%= attr?('id') ? %( id="#{attr 'id'}") : nil %><%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>

--- a/spec/htmlbook_spec.rb
+++ b/spec/htmlbook_spec.rb
@@ -5,6 +5,15 @@ describe "HTMLBook Templates" do
 
 
 	# Tests section.html.erb templates
+	it "should convert part titles" do
+	  html = Nokogiri::HTML(convert("
+[part]
+== Part Title
+
+Some introductory part text"))
+          html.xpath("//div[@data-type='part']/h1").text.should == "Part Title"
+	end
+
 	it "should convert chapter titles" do
 	    html = Nokogiri::HTML(convert("== Chapter Title"))
 		html.xpath("//section[@data-type='chapter']/h1").text.should == "Chapter Title"


### PR DESCRIPTION
Support creating part-page files (e.g., part01.asciidoc) via the following markup:

````
[part]
== Part heading

Some partintro content
````

A bit of a syntax override, as Part headings in AsciiDoc are canonically delimited with just a single `=`, but this allows for part-page files to be run through AsciiDoctor separately (outside the context of the entire book) without requiring customizations to the core codebase.