### PR TITLE
Adding support for double-paren indexterm macro.

### DIFF
--- a/htmlbook-autogen/inline_indexterm.html.erb
+++ b/htmlbook-autogen/inline_indexterm.html.erb
@@ -1,4 +1,5 @@
-<%#encoding:UTF-8%><% terms = attr :terms
+<%#encoding:UTF-8%><% if @type == :visible %><%= @text %><a data-type="indexterm" data-primary="<%= @text %>"/><% else
+terms = attr :terms
 if terms
   # From terms, Get only supported name attrs see, seealso, sortas, primary-sortas, secondary-sortas, tertiary-sortas, id, range, startref
   named_attrs = terms.select {|t| t =~ /^(see(also)?|(primary-|secondary-|tertiary-)?sortas|id|range|startref)=/} 
@@ -30,4 +31,4 @@ if terms
     else
       attr_map["primary-sortas"] = attr_map["sortas"]
     end 
-  end %><a data-type="indexterm"<%= attr_map["id"] ? %( id="#{attr_map["id"]}") : nil %><%= attr_map["primary"] ? %( data-primary="#{attr_map["primary"]}") : nil %><%= attr_map["secondary"] ? %( data-secondary="#{attr_map["secondary"]}") : nil %><%= attr_map["tertiary"] ? %( data-tertiary="#{attr_map["tertiary"]}") : nil %><%= attr_map["see"] ? %( data-see="#{attr_map["see"]}") : nil %><%= attr_map["seealso"] ? %( data-seealso="#{attr_map["seealso"]}") : nil %><%= attr_map["primary-sortas"] ? %( data-primary-sortas="#{attr_map["primary-sortas"]}") : nil %><%= attr_map["secondary-sortas"] ? %( data-secondary-sortas="#{attr_map["secondary-sortas"]}") : nil %><%= attr_map["tertiary-sortas"] ? %( data-tertiary-sortas="#{attr_map["tertiary-sortas"]}") : nil %><%= attr_map["startref"] ? %( data-startref="#{attr_map["startref"]}") : nil %>/><% end %>
+  end %><a data-type="indexterm"<%= attr_map["id"] ? %( id="#{attr_map["id"]}") : nil %><%= attr_map["primary"] ? %( data-primary="#{attr_map["primary"]}") : nil %><%= attr_map["secondary"] ? %( data-secondary="#{attr_map["secondary"]}") : nil %><%= attr_map["tertiary"] ? %( data-tertiary="#{attr_map["tertiary"]}") : nil %><%= attr_map["see"] ? %( data-see="#{attr_map["see"]}") : nil %><%= attr_map["seealso"] ? %( data-seealso="#{attr_map["seealso"]}") : nil %><%= attr_map["primary-sortas"] ? %( data-primary-sortas="#{attr_map["primary-sortas"]}") : nil %><%= attr_map["secondary-sortas"] ? %( data-secondary-sortas="#{attr_map["secondary-sortas"]}") : nil %><%= attr_map["tertiary-sortas"] ? %( data-tertiary-sortas="#{attr_map["tertiary-sortas"]}") : nil %><%= attr_map["startref"] ? %( data-startref="#{attr_map["startref"]}") : nil %>/><% end %><% end %>

--- a/htmlbook/inline_indexterm.html.erb
+++ b/htmlbook/inline_indexterm.html.erb
@@ -1,4 +1,5 @@
-<%#encoding:UTF-8%><% terms = attr :terms
+<%#encoding:UTF-8%><% if @type == :visible %><%= @text %><a data-type="indexterm" data-primary="<%= @text %>"/><% else
+terms = attr :terms
 if terms
   # From terms, Get only supported name attrs see, seealso, sortas, primary-sortas, secondary-sortas, tertiary-sortas, id, range, startref
   named_attrs = terms.select {|t| t =~ /^(see(also)?|(primary-|secondary-|tertiary-)?sortas|id|range|startref)=/} 
@@ -30,4 +31,4 @@ if terms
     else
       attr_map["primary-sortas"] = attr_map["sortas"]
     end 
-  end %><a data-type="indexterm"<%= attr_map["id"] ? %( id="#{attr_map["id"]}") : nil %><%= attr_map["primary"] ? %( data-primary="#{attr_map["primary"]}") : nil %><%= attr_map["secondary"] ? %( data-secondary="#{attr_map["secondary"]}") : nil %><%= attr_map["tertiary"] ? %( data-tertiary="#{attr_map["tertiary"]}") : nil %><%= attr_map["see"] ? %( data-see="#{attr_map["see"]}") : nil %><%= attr_map["seealso"] ? %( data-seealso="#{attr_map["seealso"]}") : nil %><%= attr_map["primary-sortas"] ? %( data-primary-sortas="#{attr_map["primary-sortas"]}") : nil %><%= attr_map["secondary-sortas"] ? %( data-secondary-sortas="#{attr_map["secondary-sortas"]}") : nil %><%= attr_map["tertiary-sortas"] ? %( data-tertiary-sortas="#{attr_map["tertiary-sortas"]}") : nil %><%= attr_map["startref"] ? %( data-startref="#{attr_map["startref"]}") : nil %>/><% end %>
+  end %><a data-type="indexterm"<%= attr_map["id"] ? %( id="#{attr_map["id"]}") : nil %><%= attr_map["primary"] ? %( data-primary="#{attr_map["primary"]}") : nil %><%= attr_map["secondary"] ? %( data-secondary="#{attr_map["secondary"]}") : nil %><%= attr_map["tertiary"] ? %( data-tertiary="#{attr_map["tertiary"]}") : nil %><%= attr_map["see"] ? %( data-see="#{attr_map["see"]}") : nil %><%= attr_map["seealso"] ? %( data-seealso="#{attr_map["seealso"]}") : nil %><%= attr_map["primary-sortas"] ? %( data-primary-sortas="#{attr_map["primary-sortas"]}") : nil %><%= attr_map["secondary-sortas"] ? %( data-secondary-sortas="#{attr_map["secondary-sortas"]}") : nil %><%= attr_map["tertiary-sortas"] ? %( data-tertiary-sortas="#{attr_map["tertiary-sortas"]}") : nil %><%= attr_map["startref"] ? %( data-startref="#{attr_map["startref"]}") : nil %>/><% end %><% end %>

--- a/spec/files/indexterm_testing.asciidoc
+++ b/spec/files/indexterm_testing.asciidoc
@@ -131,3 +131,8 @@ Plain sortas should be ignored if there is primary-sortas((("1", sortas="ignorem
 Plain sortas should be ignored if there is secondary-sortas((("1", "2", secondary-sortas="two", sortas="ignoreme2")))
 
 Plain sortas should be ignored if there is tertiary-sortas((("1", "2", "3",  tertiary-sortas="three", sortas="ignoreme3")))
+
+[[text-term-hybrid]]
+=== VIII. TEXT-TERM HYBRID
+
+((Ruby)) is my favorite programming language.

--- a/spec/htmlbook_spec.rb
+++ b/spec/htmlbook_spec.rb
@@ -614,6 +614,15 @@ Finally a reference to the second footnote.footnoteref:[note2]
                expect { Nokogiri::HTML(convert('This indexterm has unbalanced parens((("primary", "secondary"))')) }.not_to raise_error
         end
 
+	it "should properly convert text-term hybrids" do
+	       html = Nokogiri::HTML(convert_indexterm_tests)
+	       indexterm_p = html.xpath("//section[@id='text-term-hybrid']//p[1]")
+	       indexterms = html.xpath("//section[@id='text-term-hybrid']//p[1]//a[@data-type='indexterm']")
+	       indexterm_p.text.should == "Ruby is my favorite programming language."
+	       indexterms.length.should == 1
+	       indexterms.xpath("./@data-primary").text.should == "Ruby"
+	end
+
 	# Passthrough tests - moving these tests to Atlas app
 
 	# it "should convert inline DocBook passthroughs to HTMLBook" do


### PR DESCRIPTION
AsciiDoc allows you to designate body text to also be treated as a primary index term, allowing you to write shorthand markup like this:

````
((Ruby)) is my favorite programming language
````

Which is equivalent to this:

````
Ruby(("Ruby")) is my favorite programming language
````

This PR adds support for converting the shorthand markup in the first example above to proper HTMLBook output.