### PR TITLE
Adding new foreword handling.

### DIFF
--- a/htmlbook/section.html.erb
+++ b/htmlbook/section.html.erb
@@ -17,6 +17,12 @@ title_html = %(#{sectnum} #{title_html}) if !@special && (attr? 'numbered') && @
 
 <%= content %>
 </div>
+<% elsif sectname == 'foreword' %>
+<section data-type="foreword"<%= attr?('id') ? %( id="#{attr 'id'}") : nil %><%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>
+<%= %(<h#{@level}) %>><%= title %><%= %(</h#{@level}>) %>
+
+<%= content %>
+</section>
 <% elsif sectname == 'preface' and title == 'Foreword' %>
 <section data-type="foreword"<%= attr?('id') ? %( id="#{attr 'id'}") : nil %><%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>
 <%= %(<h#{@level}) %>><%= title %><%= %(</h#{@level}>) %>

--- a/spec/htmlbook_spec.rb
+++ b/spec/htmlbook_spec.rb
@@ -52,6 +52,14 @@ Some introductory part text"))
                 html.xpath("//section[@data-type='foreword']/h1").text.should == "Foreword"
         end
 
+        # New foreword handling test 5/4/2016 DESK#52924
+        it "should convert foreword titles with new syntax" do
+            html = Nokogiri::HTML(convert("
+[foreword]
+== This is my title"))
+                html.xpath("//section[@data-type='foreword']/h1").text.should == "This is my title"
+        end
+
         it "should convert Introduction titles" do
             html = Nokogiri::HTML(convert("
 [introduction]


### PR DESCRIPTION
Forewords can now be specified by using `[foreword]` before a chapter declaration, as in:

```
[foreword]
== My Title
```

 Updating section.html.erb and spec/htmlbook_spec.rb
