### PR TITLE
TOOLSREQ-8298: Use h1 titles for Sidebars in AsciiDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In this folder there's a script that helps you convert book files written in asc
 Convert a book by running the script like this:
 
 ```bash
-$ ruby scripts/convert_folder PATH_TO_BOOK_REPO
+$ ruby scripts/convert_book.rb PATH_TO_BOOK_REPO
 ```
 
 So If my book repo exists in `/Documents/MyBook`, you would do the following:

--- a/htmlbook/block_sidebar.html.erb
+++ b/htmlbook/block_sidebar.html.erb
@@ -1,4 +1,4 @@
 <%#encoding:UTF-8%><aside<%= @id && %( id="#{@id}") %> data-type="sidebar"<%= attr?('role') ? %( class="#{attr 'role'}") : nil %>>
-<h5><%= title %></h5><%= 
+<h1><%= title %></h1><%= 
 content %>
 </aside>

--- a/spec/htmlbook_spec.rb
+++ b/spec/htmlbook_spec.rb
@@ -369,7 +369,7 @@ ____
 Sidebar text is surrounded by four asterisks.
 ****
 "))
-		html.xpath("//aside[@data-type='sidebar']/h5").text.should == "Sidebar Title"
+		html.xpath("//aside[@data-type='sidebar']/h1").text.should == "Sidebar Title"
 		html.xpath("//aside[@data-type='sidebar']/p").text.should == "Sidebar text is surrounded by four asterisks."
 	end
 


### PR DESCRIPTION
Production has decided to change out default Sidebar heading from `<h5>` to `<h1>` for better display on the Platform. This PR makes that change. I also fixed an error in the README.