### PR TITLE
Nokogiri 1.16.2 Security Patch and CODEOWNERS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1
           bundler-cache: true
       - name: Run tests
         run: bundle exec rspec spec/htmlbook_spec.rb

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo.
+*       @oreillymedia/publishing-engineering @oreillymedia/tools-team

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,11 +4,11 @@ GEM
     asciidoctor (2.0.17)
     concurrent-ruby (1.1.10)
     diff-lcs (1.2.4)
-    mini_portile2 (2.8.1)
-    nokogiri (1.14.3)
-      mini_portile2 (~> 2.8.0)
+    mini_portile2 (2.8.5)
+    nokogiri (1.16.2)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    racc (1.6.2)
+    racc (1.7.3)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
@@ -30,4 +30,4 @@ DEPENDENCIES
   tilt
 
 BUNDLED WITH
-   2.3.12
+   2.4.19


### PR DESCRIPTION
Changing CI to use Ruby 3.1 and manually updating Nokogiri version for security patch. Also adding CODEOWNERS file.