### PR TITLE
Updating syntax and dependencies to match Atlas Workers Ruby version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.3.6
           bundler-cache: true
       - name: Run tests
         run: bundle exec rspec spec/htmlbook_spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby "3.3.6"
 
 group :test do
   gem "asciidoctor"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    asciidoctor (2.0.17)
-    concurrent-ruby (1.1.10)
-    diff-lcs (1.6.0)
+    asciidoctor (2.0.23)
+    concurrent-ruby (1.3.5)
+    diff-lcs (1.6.1)
     mini_portile2 (2.8.8)
-    nokogiri (1.18.4)
+    nokogiri (1.18.7)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     racc (1.8.1)
@@ -22,7 +22,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.2)
-    tilt (1.4.1)
+    tilt (2.6.0)
 
 PLATFORMS
   ruby
@@ -33,6 +33,9 @@ DEPENDENCIES
   nokogiri
   rspec
   tilt
+
+RUBY VERSION
+   ruby 3.3.6p108
 
 BUNDLED WITH
    2.4.19

--- a/scripts/convert_book.rb
+++ b/scripts/convert_book.rb
@@ -4,7 +4,7 @@ require 'asciidoctor'
 require 'fileutils'
 
 book_folder = ARGV[0]
-raise "Book Folder does not exist: #{book_folder}" unless File.exists?(book_folder)
+raise "Book Folder does not exist: #{book_folder}" unless File.exist?(book_folder)
 
 Dir.glob("#{book_folder}**/*.{asciidoc,adoc,asc}") do |file|
   puts "Converting #{File.basename(file)}"

--- a/spec/htmlbook_spec.rb
+++ b/spec/htmlbook_spec.rb
@@ -11,12 +11,12 @@ describe "HTMLBook Templates" do
 == Part Title
 
 Some introductory part text"))
-          html.xpath("//div[@data-type='part']/h1").text.should == "Part Title"
+          expect(html.xpath("//div[@data-type='part']/h1").text).to eq("Part Title")
 	end
 
 	it "should convert chapter titles" do
 	    html = Nokogiri::HTML(convert("== Chapter Title"))
-		html.xpath("//section[@data-type='chapter']/h1").text.should == "Chapter Title"
+		expect(html.xpath("//section[@data-type='chapter']/h1").text).to eq("Chapter Title")
 	 end
 
 	it "should convert preface titles" do
@@ -24,7 +24,7 @@ Some introductory part text"))
 [preface]
 == Preface
 "))
-		html.xpath("//section[@data-type='preface']/h1").text.should == "Preface"
+		expect(html.xpath("//section[@data-type='preface']/h1").text).to eq("Preface")
 	end
 
 	it "should convert appendix titles" do
@@ -32,24 +32,24 @@ Some introductory part text"))
 [appendix]
 == Appendix
 "))
-		html.xpath("//section[@data-type='appendix']/h1").text.should == "Appendix"
+		expect(html.xpath("//section[@data-type='appendix']/h1").text).to eq("Appendix")
 	end
 
         it "should convert dedication titles" do
             html = Nokogiri::HTML(convert("== Dedication"))
-                html.xpath("//section[@data-type='dedication']/h1").text.should == "Dedication"
+                expect(html.xpath("//section[@data-type='dedication']/h1").text).to eq("Dedication")
         end
 
         it "should convert glossary titles" do
             html = Nokogiri::HTML(convert("== Glossary"))
-                html.xpath("//section[@data-type='glossary']/h1").text.should == "Glossary"
+                expect(html.xpath("//section[@data-type='glossary']/h1").text).to eq("Glossary")
         end
 
         it "should convert foreword titles" do
             html = Nokogiri::HTML(convert("
 [preface]
 == Foreword"))
-                html.xpath("//section[@data-type='foreword']/h1").text.should == "Foreword"
+                expect(html.xpath("//section[@data-type='foreword']/h1").text).to eq("Foreword")
         end
 
         # New foreword handling test 5/4/2016 DESK#52924
@@ -57,39 +57,39 @@ Some introductory part text"))
             html = Nokogiri::HTML(convert("
 [foreword]
 == This is my title"))
-                html.xpath("//section[@data-type='foreword']/h1").text.should == "This is my title"
+                expect(html.xpath("//section[@data-type='foreword']/h1").text).to eq("This is my title")
         end
 
         it "should convert Introduction titles" do
             html = Nokogiri::HTML(convert("
 [introduction]
 == This is the Introduction"))
-                html.xpath("//section[@data-type='introduction']/h1").text.should == "This is the Introduction"
+                expect(html.xpath("//section[@data-type='introduction']/h1").text).to eq("This is the Introduction")
         end
 
         it "should convert index titles" do
             html = Nokogiri::HTML(convert("== Index"))
-                html.xpath("//section[@data-type='index']/h1").text.should == "Index"
+                expect(html.xpath("//section[@data-type='index']/h1").text).to eq("Index")
         end
 
 	it "should convert level 1 headings" do
 	    html = Nokogiri::HTML(convert("=== Heading 1"))
-		html.xpath("//section[@data-type='sect1']/h1").text.should == "Heading 1"
+		expect(html.xpath("//section[@data-type='sect1']/h1").text).to eq("Heading 1")
 	end
 
 	it "should convert level 2 headings" do
 		html = Nokogiri::HTML(convert("==== Heading 2"))
-		html.xpath("//section[@data-type='sect2']/h2").text.should == "Heading 2"
+		expect(html.xpath("//section[@data-type='sect2']/h2").text).to eq("Heading 2")
 	end
 
 	it "should convert level 3 headings" do
 		html = Nokogiri::HTML(convert("===== Heading 3"))
-		html.xpath("//section[@data-type='sect3']/h3").text.should == "Heading 3"
+		expect(html.xpath("//section[@data-type='sect3']/h3").text).to eq("Heading 3")
 	end
 
 	it "should convert level 4 headings" do
 		html = Nokogiri::HTML(convert("====== Heading 4"))
-		html.xpath("//section[@data-type='sect4']/h4").text.should == "Heading 4"
+		expect(html.xpath("//section[@data-type='sect4']/h4").text).to eq("Heading 4")
 	end
 
 	# Tests block_admonition template
@@ -102,8 +102,8 @@ Here is a note with block markup.
 Here is a second paragraph.
 ====
 "))
-		html.xpath("//div[@data-type='note']/p[1]").text.should == "Here is a note with block markup."
-		html.xpath("//div[@data-type='note']/p[2]").text.should == "Here is a second paragraph."
+		expect(html.xpath("//div[@data-type='note']/p[1]").text).to eq("Here is a note with block markup.")
+		expect(html.xpath("//div[@data-type='note']/p[2]").text).to eq("Here is a second paragraph.")
 	end
 
 	# Tests block_admonition template alternate markup
@@ -112,7 +112,7 @@ Here is a second paragraph.
 [NOTE]
 Here is a note with paragraph markup.
 "))
-		html.xpath("//div[@data-type='note']/p").text.should == "Here is a note with paragraph markup."
+		expect(html.xpath("//div[@data-type='note']/p").text).to eq("Here is a note with paragraph markup.")
 	end
 
 	# Tests block_admonition template second alternate markup
@@ -120,7 +120,7 @@ Here is a note with paragraph markup.
 		html = Nokogiri::HTML(convert("
 NOTE: Here is a note with alternate paragraph markup.
 "))
-		html.xpath("//div[@data-type='note']/p").text.should == "Here is a note with alternate paragraph markup."
+		expect(html.xpath("//div[@data-type='note']/p").text).to eq("Here is a note with alternate paragraph markup.")
 	end
 
 
@@ -131,7 +131,7 @@ NOTE: Here is a note with alternate paragraph markup.
 Here is some text inside a tip.
 ====
 "))
-		html.xpath("//div[@data-type='tip']/p").text.should == "Here is some text inside a tip."
+		expect(html.xpath("//div[@data-type='tip']/p").text).to eq("Here is some text inside a tip.")
 	end
 
 
@@ -142,7 +142,7 @@ Here is some text inside a tip.
 Here is some text inside a warning.
 ====
 "))
-		html.xpath("//div[@data-type='warning']/p").text.should == "Here is some text inside a warning."
+		expect(html.xpath("//div[@data-type='warning']/p").text).to eq("Here is some text inside a warning.")
 	end
 
 	it "should convert cautions" do
@@ -152,15 +152,15 @@ Here is some text inside a warning.
 Here is some text inside a caution.
 ====
 "))
-		html.xpath("//div[@data-type='caution']/p").text.should == "Here is some text inside a caution."
+		expect(html.xpath("//div[@data-type='caution']/p").text).to eq("Here is some text inside a caution.")
 	end
 
 
 	# Tests block_dlist template
 	it "should convert definition/variable list terms" do
 		html = Nokogiri::HTML(convert("First term:: This is a definition of the first term."))
-		html.xpath("//dl/dt").text.should == "First term"
-		html.xpath("//dl/dd/p").text.should == "This is a definition of the first term."
+		expect(html.xpath("//dl/dt").text).to eq("First term")
+		expect(html.xpath("//dl/dd/p").text).to eq("This is a definition of the first term.")
 	end
 
 
@@ -176,10 +176,10 @@ Hello world
 ----
 ====
 "))
-		html.xpath("//div[@data-type='example']/@id").text.should == "Example1"
-		html.xpath("//div[@data-type='example']/h5").text.should == "A code block with a title"
-		html.xpath("//div[@data-type='example']/pre[@data-type='programlisting']/@data-code-language").text.should == "php"
-		html.xpath("//div[@data-type='example']/pre[@data-type='programlisting']").text.should == "Hello world"
+		expect(html.xpath("//div[@data-type='example']/@id").text).to eq("Example1")
+		expect(html.xpath("//div[@data-type='example']/h5").text).to eq("A code block with a title")
+		expect(html.xpath("//div[@data-type='example']/pre[@data-type='programlisting']/@data-code-language").text).to eq("php")
+		expect(html.xpath("//div[@data-type='example']/pre[@data-type='programlisting']").text).to eq("Hello world")
 	end
 
 	# Test linenumbering attribute
@@ -195,12 +195,12 @@ Hello world again
 ====
 
 "))
-		html.xpath("//div[@data-type='example'][1]/@id").text.should == "Example2"
-		html.xpath("//div[@data-type='example'][1]/h5").text.should == "Another code block with a title"
-		html.xpath("//div[@data-type='example'][1]/pre[@data-type='programlisting']").text.should == "Hello world again"
+		expect(html.xpath("//div[@data-type='example'][1]/@id").text).to eq("Example2")
+		expect(html.xpath("//div[@data-type='example'][1]/h5").text).to eq("Another code block with a title")
+		expect(html.xpath("//div[@data-type='example'][1]/pre[@data-type='programlisting']").text).to eq("Hello world again")
 		html.xpath("//pre[1]/@data-line-numbering").text.should_not == ""
-		html.xpath("//div[@data-type='example'][1]/pre/@data-line-numbering").text.should == "numbered"
-		html.xpath("//div[@data-type='example'][1]/pre[@data-type='programlisting']/@data-code-language").text.should == "php"
+		expect(html.xpath("//div[@data-type='example'][1]/pre/@data-line-numbering").text).to eq("numbered")
+		expect(html.xpath("//div[@data-type='example'][1]/pre[@data-type='programlisting']/@data-code-language").text).to eq("php")
 	end
 
 	it "should convert line numbering attribute in informal code listing" do
@@ -211,10 +211,10 @@ Hello world again
 ----
 
 "))
-		html.xpath("//pre[@data-type='programlisting'][1]").text.should == "Hello world again"
+		expect(html.xpath("//pre[@data-type='programlisting'][1]").text).to eq("Hello world again")
 		html.xpath("//pre[1]/@data-line-numbering").text.should_not == ""
-		html.xpath("//pre[1]/@data-line-numbering").text.should == "numbered"
-		html.xpath("//pre[@data-type='programlisting'][1]/@data-code-language").text.should == "php"
+		expect(html.xpath("//pre[1]/@data-line-numbering").text).to eq("numbered")
+		expect(html.xpath("//pre[@data-type='programlisting'][1]/@data-code-language").text).to eq("php")
 	end
 
 
@@ -225,10 +225,10 @@ Hello world again
 .A Figure
 image::images/tiger.png[]
 "))
-		html.xpath("//figure/@id").text.should == "unique_id1"
-		html.xpath("//figure/figcaption").text.should == "A Figure"
-		html.xpath("//figure/img/@src").text.should == "images/tiger.png"
-		html.xpath("//figure/img/@alt").text.should == "tiger"
+		expect(html.xpath("//figure/@id").text).to eq("unique_id1")
+		expect(html.xpath("//figure/figcaption").text).to eq("A Figure")
+		expect(html.xpath("//figure/img/@src").text).to eq("images/tiger.png")
+		expect(html.xpath("//figure/img/@alt").text).to eq("tiger")
 	end
 
 
@@ -236,32 +236,32 @@ image::images/tiger.png[]
 		html = Nokogiri::HTML(convert("image::images/duck.png[]"))
 		html.xpath("//figure/figcaption").size.should == 1
 		html.xpath("//figure/@id").size.should == 0
-		html.xpath("//figure/img/@src").text.should == "images/duck.png"
+		expect(html.xpath("//figure/img/@src").text).to eq("images/duck.png")
 	end
 
 	it "should convert figures with alt-text" do
 		html = Nokogiri::HTML(convert("image::images/lion.png['An image of a lion head']"))
-		html.xpath("//figure/img/@alt").text.should == "An image of a lion head"
+		expect(html.xpath("//figure/img/@alt").text).to eq("An image of a lion head")
 	end
 
 	it "should convert figures with a width attributes" do
 		html = Nokogiri::HTML(convert("image::images/lion.png[width='99in']"))
-		html.xpath("//figure/img/@width").text.should == "99in"
+		expect(html.xpath("//figure/img/@width").text).to eq("99in")
 	end
 
 	it "should convert figures with a width attributes when other attributes are present" do
 		html = Nokogiri::HTML(convert("image::images/lion.png[width='4in', height='2in']"))
-		html.xpath("//figure/img/@width").text.should == "4in"
+		expect(html.xpath("//figure/img/@width").text).to eq("4in")
 	end
 
 	it "should convert figures with a height attributes" do
 		html = Nokogiri::HTML(convert("image::images/lion.png[height='3in']"))
-		html.xpath("//figure/img/@height").text.should == "3in"
+		expect(html.xpath("//figure/img/@height").text).to eq("3in")
 	end
 
 	it "should convert figures with a height attributes when other attributes are present" do
 		html = Nokogiri::HTML(convert("image::images/lion.png[width='5in', height='2in']"))
-		html.xpath("//figure/img/@height").text.should == "2in"
+		expect(html.xpath("//figure/img/@height").text).to eq("2in")
 	end
 
 
@@ -273,8 +273,8 @@ image::images/tiger.png[]
 Hello world
 ----
 "))
-		html.xpath("//pre[@data-type='programlisting']/@data-code-language").text.should == "php"
-		html.xpath("//pre[@data-type='programlisting']").text.should == "Hello world"
+		expect(html.xpath("//pre[@data-type='programlisting']/@data-code-language").text).to eq("php")
+		expect(html.xpath("//pre[@data-type='programlisting']").text).to eq("Hello world")
 	end
 
 	# Tests block_literal template - first markup style
@@ -283,13 +283,13 @@ Hello world
 [literal]
 This is a literal block.
 "))
-		html.xpath("//pre").text.should == "This is a literal block."
+		expect(html.xpath("//pre").text).to eq("This is a literal block.")
 	end
 
 	# Tests block_literal template - second markup style
 	it "should convert literal blocks" do
 		html = Nokogiri::HTML(convert(" This is also a literal block."))
-		html.xpath("//pre").text.should == "This is also a literal block."
+		expect(html.xpath("//pre").text).to eq("This is also a literal block.")
 	end
 
 	# Test block_math template
@@ -303,7 +303,7 @@ This is a literal block.
 \end{equation}
 ++++
 "))
-		html.xpath("//div[@data-type='equation']/h5").text.should == "Equation title"
+		expect(html.xpath("//div[@data-type='equation']/h5").text).to eq("Equation title")
 		html.xpath("//div[@data-type='equation']/p[@data-type='latex']/text()") == "
 \begin{equation}
 {x = \frac{{ - b \pm \sqrt {b^2 - 4ac} }}{{2a}}}
@@ -324,18 +324,18 @@ Bake
 +
 . Applause
 "))
-		html.xpath("//ol/li[1]/p[1]").text.should == "Preparation"
-		html.xpath("//ol/li[2]/p[1]").text.should == "Assembly"
-		html.xpath("//ol/li[3]/p[1]").text.should == "Measure"
-		html.xpath("//ol/li[3]/p[2]").text.should == "Combine"
-		html.xpath("//ol/li[3]/p[3]").text.should == "Bake"
-		html.xpath("//ol/li[4]/p[1]").text.should == "Applause"
+		expect(html.xpath("//ol/li[1]/p[1]").text).to eq("Preparation")
+		expect(html.xpath("//ol/li[2]/p[1]").text).to eq("Assembly")
+		expect(html.xpath("//ol/li[3]/p[1]").text).to eq("Measure")
+		expect(html.xpath("//ol/li[3]/p[2]").text).to eq("Combine")
+		expect(html.xpath("//ol/li[3]/p[3]").text).to eq("Bake")
+		expect(html.xpath("//ol/li[4]/p[1]").text).to eq("Applause")
 	end
 
 	# Tests block_paragraph template
 	it "should convert regular paragraphs" do
 		html = Nokogiri::HTML(convert("Here is a basic paragraph."))
-		html.xpath("//p").text.should == "Here is a basic paragraph."
+		expect(html.xpath("//p").text).to eq("Here is a basic paragraph.")
 	end
 
 	it "should convert paragraphs with role attributes" do
@@ -343,7 +343,7 @@ Bake
 [role='right']
 Here is a basic paragraph.
 "))
-		html.xpath("//p[@class='right']").text.should == "Here is a basic paragraph."
+		expect(html.xpath("//p[@class='right']").text).to eq("Here is a basic paragraph.")
 	end
 
 	# Tests block_quote template
@@ -356,9 +356,9 @@ Many thanks; I shall lose no time in reading it.
 This is a second paragraph in the quotation.
 ____
 "))
-		html.xpath("//blockquote/p[1]").text.should == "Many thanks; I shall lose no time in reading it."
-		html.xpath("//blockquote/p[2]").text.should == "This is a second paragraph in the quotation."
-		html.xpath("//blockquote/p[@data-type='attribution']").text.should == "Wilfred Meynell"
+		expect(html.xpath("//blockquote/p[1]").text).to eq("Many thanks; I shall lose no time in reading it.")
+		expect(html.xpath("//blockquote/p[2]").text).to eq("This is a second paragraph in the quotation.")
+		expect(html.xpath("//blockquote/p[@data-type='attribution']").text).to eq("Wilfred Meynell")
 	end
 
 	# Tests block_sidebar template
@@ -369,8 +369,8 @@ ____
 Sidebar text is surrounded by four asterisks.
 ****
 "))
-		html.xpath("//aside[@data-type='sidebar']/h1").text.should == "Sidebar Title"
-		html.xpath("//aside[@data-type='sidebar']/p").text.should == "Sidebar text is surrounded by four asterisks."
+		expect(html.xpath("//aside[@data-type='sidebar']/h1").text).to eq("Sidebar Title")
+		expect(html.xpath("//aside[@data-type='sidebar']/p").text).to eq("Sidebar text is surrounded by four asterisks.")
 	end
 
 	# Tests block_table template
@@ -384,14 +384,14 @@ Sidebar text is surrounded by four asterisks.
 |row2|col2
 |=======
 "))
-		html.xpath("//table/caption").text.should == "Table Title"
-		html.xpath("//table/thead/tr/th[1]").text.should == "header1"
-		html.xpath("//table/thead/tr/th[2]").text.should == "header2"
-		html.xpath("//table/tbody/tr[1]/td[1]/p").text.should == "row1"
-		html.xpath("//table/tbody/tr[1]/td[2]/p/text()").text.should == "P"
-		html.xpath("//table/tbody/tr[1]/td[2]/p/sup").text.should == "Q"
-		html.xpath("//table/tbody/tr[2]/td[1]/p").text.should == "row2"
-		html.xpath("//table/tbody/tr[2]/td[2]/p").text.should == "col2"
+		expect(html.xpath("//table/caption").text).to eq("Table Title")
+		expect(html.xpath("//table/thead/tr/th[1]").text).to eq("header1")
+		expect(html.xpath("//table/thead/tr/th[2]").text).to eq("header2")
+		expect(html.xpath("//table/tbody/tr[1]/td[1]/p").text).to eq("row1")
+		expect(html.xpath("//table/tbody/tr[1]/td[2]/p/text()").text).to eq("P")
+		expect(html.xpath("//table/tbody/tr[1]/td[2]/p/sup").text).to eq("Q")
+		expect(html.xpath("//table/tbody/tr[2]/td[1]/p").text).to eq("row2")
+		expect(html.xpath("//table/tbody/tr[2]/td[2]/p").text).to eq("col2")
 	end
 
 	it "should convert informal tables (no title or header)" do
@@ -401,11 +401,11 @@ Sidebar text is surrounded by four asterisks.
 |row2|col2
 |=======
 "))
-		html.xpath("//table/tbody/tr[1]/td[1]/p").text.should == "row1"
-		html.xpath("//table/tbody/tr[1]/td[2]/p/text()").text.should == "P"
-		html.xpath("//table/tbody/tr[1]/td[2]/p/sup").text.should == "Q"
-		html.xpath("//table/tbody/tr[2]/td[1]/p").text.should == "row2"
-		html.xpath("//table/tbody/tr[2]/td[2]/p").text.should == "col2"
+		expect(html.xpath("//table/tbody/tr[1]/td[1]/p").text).to eq("row1")
+		expect(html.xpath("//table/tbody/tr[1]/td[2]/p/text()").text).to eq("P")
+		expect(html.xpath("//table/tbody/tr[1]/td[2]/p/sup").text).to eq("Q")
+		expect(html.xpath("//table/tbody/tr[2]/td[1]/p").text).to eq("row2")
+		expect(html.xpath("//table/tbody/tr[2]/td[2]/p").text).to eq("col2")
 	end
 
 	# Tests block_ulist template
@@ -420,11 +420,11 @@ teapotted
 +
 * lions, tigers, and bears
 "))
-		html.xpath("//ul/li[1]/p[1]").text.should == "lions"
-		html.xpath("//ul/li[2]/p[1]").text.should == "tigers"
-		html.xpath("//ul/li[2]/p[2]").text.should == "sabre-toothed"
-		html.xpath("//ul/li[2]/p[3]").text.should == "teapotted"
-		html.xpath("//ul/li[3]/p[1]").text.should == "lions, tigers, and bears"
+		expect(html.xpath("//ul/li[1]/p[1]").text).to eq("lions")
+		expect(html.xpath("//ul/li[2]/p[1]").text).to eq("tigers")
+		expect(html.xpath("//ul/li[2]/p[2]").text).to eq("sabre-toothed")
+		expect(html.xpath("//ul/li[2]/p[3]").text).to eq("teapotted")
+		expect(html.xpath("//ul/li[3]/p[1]").text).to eq("lions, tigers, and bears")
 	end
 
 	# Tests block_verse template
@@ -436,7 +436,7 @@ In the forests of the night
 "))
 		html.xpath("//blockquote/pre").text.should == "Tiger, tiger, burning bright
 In the forests of the night"
-		html.xpath("//blockquote/p[@data-type='attribution']").text.should == "— William Blake, Songs of Experience"
+		expect(html.xpath("//blockquote/p[@data-type='attribution']").text).to eq("— William Blake, Songs of Experience")
 	end
 
 	# Tests block_video template
@@ -445,8 +445,8 @@ In the forests of the night"
 		html = Nokogiri::HTML(convert("
 video::gizmo.ogv[width=200]
 "))
-		html.xpath("//video[@width='200']/source/@src").text.should == "gizmo.ogv"
-		html.xpath("//video/text()").text.should == "\nSorry, the <video> element is not supported in your reading system.\n"
+		expect(html.xpath("//video[@width='200']/source/@src").text).to eq("gizmo.ogv")
+		expect(html.xpath("//video/text()").text).to eq("\nSorry, the <video> element is not supported in your reading system.\n")
 	end
 
 	# Tests inline_anchor template
@@ -456,10 +456,10 @@ This is a reference to an <<inlineanchor>>.
 
 See <<inlineanchor, Awesome Chapter>>
 "))
-		html.xpath("//p[1]/a/@href").text.should == "#inlineanchor"
-		html.xpath("//p[1]/a").text.should == ""
-		html.xpath("//p[2]/a/@href").text.should == "#inlineanchor"
-		html.xpath("//p[2]/a").text.should == "Awesome Chapter"
+		expect(html.xpath("//p[1]/a/@href").text).to eq("#inlineanchor")
+		expect(html.xpath("//p[1]/a").text).to eq("")
+		expect(html.xpath("//p[2]/a/@href").text).to eq("#inlineanchor")
+		expect(html.xpath("//p[2]/a").text).to eq("Awesome Chapter")
 	end
 
         it "should convert inline anchors" do
@@ -468,10 +468,10 @@ This is a link without a text node: http://www.oreilly.com
 
 This is a link with a text node: http://www.oreilly.com[check out this text node]
 "))
-                html.xpath("//p[1]/a/@href").text.should == "http://www.oreilly.com"
-                html.xpath("//p[1]/a/em[@class='hyperlink']").text.should == "http://www.oreilly.com"
-                html.xpath("//p[2]/a/@href").text.should == "http://www.oreilly.com"
-                html.xpath("//p[2]/a[not(*)]").text.should == "check out this text node"
+                expect(html.xpath("//p[1]/a/@href").text).to eq("http://www.oreilly.com")
+                expect(html.xpath("//p[1]/a/em[@class='hyperlink']").text).to eq("http://www.oreilly.com")
+                expect(html.xpath("//p[2]/a/@href").text).to eq("http://www.oreilly.com")
+                expect(html.xpath("//p[2]/a[not(*)]").text).to eq("check out this text node")
         end
 
     # Callout handling
@@ -494,7 +494,7 @@ Fourth Hello <4>
 
 
 "))		
-		html.xpath("//pre[@data-type='programlisting']").text.should == "Hello World \nHello Again \n\nThrice Hello \n{\n   Blah\n}\n\nFourth Hello "
+		expect(html.xpath("//pre[@data-type='programlisting']").text).to eq("Hello World \nHello Again \n\nThrice Hello \n{\n   Blah\n}\n\nFourth Hello ")
 		end
 
 	# Tests block_colist template
@@ -510,17 +510,17 @@ Hello Again <2>
 <1> First time.
 <2> Second time.
 "))
-		html.xpath("//dl/dt[1]/a/@class").text.should == "co"
-		html.xpath("//dl/dt[1]/a/@href").text.should == "#co_required_title_CO1-1"
-		html.xpath("//dl/dt[1]/a/@id").text.should == "callout_required_title_CO1-1"
-		html.xpath("//dl/dt[1]/a/img/@src").text.should == "callouts/1.png"
-		html.xpath("//dl/dt[1]/a/img/@alt").text.should == "1"
+		expect(html.xpath("//dl/dt[1]/a/@class").text).to eq("co")
+		expect(html.xpath("//dl/dt[1]/a/@href").text).to eq("#co_required_title_CO1-1")
+		expect(html.xpath("//dl/dt[1]/a/@id").text).to eq("callout_required_title_CO1-1")
+		expect(html.xpath("//dl/dt[1]/a/img/@src").text).to eq("callouts/1.png")
+		expect(html.xpath("//dl/dt[1]/a/img/@alt").text).to eq("1")
 
-		html.xpath("//dl/dt[2]/a/@class").text.should == "co"
-		html.xpath("//dl/dt[2]/a/@href").text.should == "#co_required_title_CO1-2"
-		html.xpath("//dl/dt[2]/a/@id").text.should == "callout_required_title_CO1-2"
-		html.xpath("//dl/dt[2]/a/img/@src").text.should == "callouts/2.png"
-		html.xpath("//dl/dt[2]/a/img/@alt").text.should == "2"
+		expect(html.xpath("//dl/dt[2]/a/@class").text).to eq("co")
+		expect(html.xpath("//dl/dt[2]/a/@href").text).to eq("#co_required_title_CO1-2")
+		expect(html.xpath("//dl/dt[2]/a/@id").text).to eq("callout_required_title_CO1-2")
+		expect(html.xpath("//dl/dt[2]/a/img/@src").text).to eq("callouts/2.png")
+		expect(html.xpath("//dl/dt[2]/a/img/@alt").text).to eq("2")
 		end
 
 		it "should convert calloutlists with a code example preceding with duplicate callouts in code" do
@@ -536,17 +536,17 @@ Hello Again <2>
 <1> First time.
 <2> Second time.
 "))			
-			html.xpath("//dl/dt[1]/a/@class").text.should == "co"
-			html.xpath("//dl/dt[1]/a/@href").text.should == "#co_required_title_CO1-1"
-			html.xpath("//dl/dt[1]/a/@id").text.should == "callout_required_title_CO1-1"
-			html.xpath("//dl/dt[1]/a/img/@src").text.should == "callouts/1.png"
-			html.xpath("//dl/dt[1]/a/img/@alt").text.should == "1"
+			expect(html.xpath("//dl/dt[1]/a/@class").text).to eq("co")
+			expect(html.xpath("//dl/dt[1]/a/@href").text).to eq("#co_required_title_CO1-1")
+			expect(html.xpath("//dl/dt[1]/a/@id").text).to eq("callout_required_title_CO1-1")
+			expect(html.xpath("//dl/dt[1]/a/img/@src").text).to eq("callouts/1.png")
+			expect(html.xpath("//dl/dt[1]/a/img/@alt").text).to eq("1")
 
-			html.xpath("//dl/dt[2]/a/@class").text.should == "co"
-			html.xpath("//dl/dt[2]/a/@href").text.should == "#co_required_title_CO1-3"
-			html.xpath("//dl/dt[2]/a/@id").text.should == "callout_required_title_CO1-2"
-			html.xpath("//dl/dt[2]/a/img/@src").text.should == "callouts/2.png"
-			html.xpath("//dl/dt[2]/a/img/@alt").text.should == "2"
+			expect(html.xpath("//dl/dt[2]/a/@class").text).to eq("co")
+			expect(html.xpath("//dl/dt[2]/a/@href").text).to eq("#co_required_title_CO1-3")
+			expect(html.xpath("//dl/dt[2]/a/@id").text).to eq("callout_required_title_CO1-2")
+			expect(html.xpath("//dl/dt[2]/a/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//dl/dt[2]/a/img/@alt").text).to eq("2")
 			end
 
 		it "should convert calloutlists with a code example preceding with callouts out of order" do
@@ -562,17 +562,17 @@ What evs. <1>
 <1> First time.
 <2> Second time.
 "))
-			html.xpath("//dl/dt[1]/a/@class").text.should == "co"
-			html.xpath("//dl/dt[1]/a/@href").text.should == "#co_required_title_CO1-2"
-			html.xpath("//dl/dt[1]/a/@id").text.should == "callout_required_title_CO1-1"
-			html.xpath("//dl/dt[1]/a/img/@src").text.should == "callouts/1.png"
-			html.xpath("//dl/dt[1]/a/img/@alt").text.should == "1"
+			expect(html.xpath("//dl/dt[1]/a/@class").text).to eq("co")
+			expect(html.xpath("//dl/dt[1]/a/@href").text).to eq("#co_required_title_CO1-2")
+			expect(html.xpath("//dl/dt[1]/a/@id").text).to eq("callout_required_title_CO1-1")
+			expect(html.xpath("//dl/dt[1]/a/img/@src").text).to eq("callouts/1.png")
+			expect(html.xpath("//dl/dt[1]/a/img/@alt").text).to eq("1")
 
-			html.xpath("//dl/dt[2]/a/@class").text.should == "co"
-			html.xpath("//dl/dt[2]/a/@href").text.should == "#co_required_title_CO1-1"
-			html.xpath("//dl/dt[2]/a/@id").text.should == "callout_required_title_CO1-2"
-			html.xpath("//dl/dt[2]/a/img/@src").text.should == "callouts/2.png"
-			html.xpath("//dl/dt[2]/a/img/@alt").text.should == "2"
+			expect(html.xpath("//dl/dt[2]/a/@class").text).to eq("co")
+			expect(html.xpath("//dl/dt[2]/a/@href").text).to eq("#co_required_title_CO1-1")
+			expect(html.xpath("//dl/dt[2]/a/@id").text).to eq("callout_required_title_CO1-2")
+			expect(html.xpath("//dl/dt[2]/a/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//dl/dt[2]/a/img/@alt").text).to eq("2")
 			end
 
 		it "should convert calloutlists with a code example preceding with duplicate callouts with callouts out of order" do
@@ -588,17 +588,17 @@ Yeah me too. <2>
 <1> First time.
 <2> Second time.
 "))
-			html.xpath("//dl/dt[1]/a/@class").text.should == "co"
-			html.xpath("//dl/dt[1]/a/@href").text.should == "#co_required_title_CO1-2"
-			html.xpath("//dl/dt[1]/a/@id").text.should == "callout_required_title_CO1-1"
-			html.xpath("//dl/dt[1]/a/img/@src").text.should == "callouts/1.png"
-			html.xpath("//dl/dt[1]/a/img/@alt").text.should == "1"
+			expect(html.xpath("//dl/dt[1]/a/@class").text).to eq("co")
+			expect(html.xpath("//dl/dt[1]/a/@href").text).to eq("#co_required_title_CO1-2")
+			expect(html.xpath("//dl/dt[1]/a/@id").text).to eq("callout_required_title_CO1-1")
+			expect(html.xpath("//dl/dt[1]/a/img/@src").text).to eq("callouts/1.png")
+			expect(html.xpath("//dl/dt[1]/a/img/@alt").text).to eq("1")
 
-			html.xpath("//dl/dt[2]/a/@class").text.should == "co"
-			html.xpath("//dl/dt[2]/a/@href").text.should == "#co_required_title_CO1-1"
-			html.xpath("//dl/dt[2]/a/@id").text.should == "callout_required_title_CO1-2"
-			html.xpath("//dl/dt[2]/a/img/@src").text.should == "callouts/2.png"
-			html.xpath("//dl/dt[2]/a/img/@alt").text.should == "2"
+			expect(html.xpath("//dl/dt[2]/a/@class").text).to eq("co")
+			expect(html.xpath("//dl/dt[2]/a/@href").text).to eq("#co_required_title_CO1-1")
+			expect(html.xpath("//dl/dt[2]/a/@id").text).to eq("callout_required_title_CO1-2")
+			expect(html.xpath("//dl/dt[2]/a/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//dl/dt[2]/a/img/@alt").text).to eq("2")
 			end
 
 		it "should convert calloutlists with a code example preceding when a number in the calloutlist does not correspond to a code callout" do
@@ -613,17 +613,17 @@ I suppose. <2>
 <1> This is true.
 <3> Third time is a... mistake.
 "))
-			html.xpath("//dl/dt[1]/a/@class").text.should == "co"
-			html.xpath("//dl/dt[1]/a/@href").text.should == "#co_required_title_CO1-1"
-			html.xpath("//dl/dt[1]/a/@id").text.should == "callout_required_title_CO1-1"
-			html.xpath("//dl/dt[1]/a/img/@src").text.should == "callouts/1.png"
-			html.xpath("//dl/dt[1]/a/img/@alt").text.should == "1"
+			expect(html.xpath("//dl/dt[1]/a/@class").text).to eq("co")
+			expect(html.xpath("//dl/dt[1]/a/@href").text).to eq("#co_required_title_CO1-1")
+			expect(html.xpath("//dl/dt[1]/a/@id").text).to eq("callout_required_title_CO1-1")
+			expect(html.xpath("//dl/dt[1]/a/img/@src").text).to eq("callouts/1.png")
+			expect(html.xpath("//dl/dt[1]/a/img/@alt").text).to eq("1")
 
-			html.xpath("//dl/dt[2]/a/@class").text.should == "co"
-			html.xpath("//dl/dt[2]/a/@href").text.should == "#co_required_title_CO1-2"
-			html.xpath("//dl/dt[2]/a/@id").text.should == "callout_required_title_CO1-2"
-			html.xpath("//dl/dt[2]/a/img/@src").text.should == "callouts/2.png"
-			html.xpath("//dl/dt[2]/a/img/@alt").text.should == "2"
+			expect(html.xpath("//dl/dt[2]/a/@class").text).to eq("co")
+			expect(html.xpath("//dl/dt[2]/a/@href").text).to eq("#co_required_title_CO1-2")
+			expect(html.xpath("//dl/dt[2]/a/@id").text).to eq("callout_required_title_CO1-2")
+			expect(html.xpath("//dl/dt[2]/a/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//dl/dt[2]/a/img/@alt").text).to eq("2")
 			end
 
 	it "should convert calloutlists without a code example preceding" do
@@ -635,17 +635,17 @@ Friends, Dean Roman, and countrymen. It's time for an IT meeting.
 <1> This is a calloutlist item.
 <2> Maybe we should have waited for some code.
 "))
-			html.xpath("//dl/dt[1]/a/@class").text.should == "co"
-			html.xpath("//dl/dt[1]/a/@href").text.should == "#co_required_title_"
-			html.xpath("//dl/dt[1]/a/@id").text.should == "callout_required_title_"
-			html.xpath("//dl/dt[1]/a/img/@src").text.should == "callouts/1.png"
-			html.xpath("//dl/dt[1]/a/img/@alt").text.should == "1"
+			expect(html.xpath("//dl/dt[1]/a/@class").text).to eq("co")
+			expect(html.xpath("//dl/dt[1]/a/@href").text).to eq("#co_required_title_")
+			expect(html.xpath("//dl/dt[1]/a/@id").text).to eq("callout_required_title_")
+			expect(html.xpath("//dl/dt[1]/a/img/@src").text).to eq("callouts/1.png")
+			expect(html.xpath("//dl/dt[1]/a/img/@alt").text).to eq("1")
 
-			html.xpath("//dl/dt[2]/a/@class").text.should == "co"
-			html.xpath("//dl/dt[2]/a/@href").text.should == "#co_required_title_"
-			html.xpath("//dl/dt[2]/a/@id").text.should == "callout_required_title_"
-			html.xpath("//dl/dt[2]/a/img/@src").text.should == "callouts/2.png"
-			html.xpath("//dl/dt[2]/a/img/@alt").text.should == "2"
+			expect(html.xpath("//dl/dt[2]/a/@class").text).to eq("co")
+			expect(html.xpath("//dl/dt[2]/a/@href").text).to eq("#co_required_title_")
+			expect(html.xpath("//dl/dt[2]/a/@id").text).to eq("callout_required_title_")
+			expect(html.xpath("//dl/dt[2]/a/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//dl/dt[2]/a/img/@alt").text).to eq("2")
 		end
 
 	it "should convert calloutlists without a code example preceding with non sequential list numbering" do
@@ -658,17 +658,17 @@ Friends, Dean Roman, and countrymen. It's time for an IT meeting.
 <1> This is a calloutlist item.
 <3> Maybe we should have waited for some code.
 "))
-			html.xpath("//dl/dt[1]/a/@class").text.should == "co"
-			html.xpath("//dl/dt[1]/a/@href").text.should == "#co_required_title_"
-			html.xpath("//dl/dt[1]/a/@id").text.should == "callout_required_title_"
-			html.xpath("//dl/dt[1]/a/img/@src").text.should == "callouts/1.png"
-			html.xpath("//dl/dt[1]/a/img/@alt").text.should == "1"
+			expect(html.xpath("//dl/dt[1]/a/@class").text).to eq("co")
+			expect(html.xpath("//dl/dt[1]/a/@href").text).to eq("#co_required_title_")
+			expect(html.xpath("//dl/dt[1]/a/@id").text).to eq("callout_required_title_")
+			expect(html.xpath("//dl/dt[1]/a/img/@src").text).to eq("callouts/1.png")
+			expect(html.xpath("//dl/dt[1]/a/img/@alt").text).to eq("1")
 
-			html.xpath("//dl/dt[2]/a/@class").text.should == "co"
-			html.xpath("//dl/dt[2]/a/@href").text.should == "#co_required_title_"
-			html.xpath("//dl/dt[2]/a/@id").text.should == "callout_required_title_"
-			html.xpath("//dl/dt[2]/a/img/@src").text.should == "callouts/2.png"
-			html.xpath("//dl/dt[2]/a/img/@alt").text.should == "2"
+			expect(html.xpath("//dl/dt[2]/a/@class").text).to eq("co")
+			expect(html.xpath("//dl/dt[2]/a/@href").text).to eq("#co_required_title_")
+			expect(html.xpath("//dl/dt[2]/a/@id").text).to eq("callout_required_title_")
+			expect(html.xpath("//dl/dt[2]/a/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//dl/dt[2]/a/img/@alt").text).to eq("2")
 		end
 
 	# Tests inline_callout template 
@@ -684,17 +684,17 @@ Hello Again <2>
 <1> First time.
 <2> Second time.
 "))
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@href").text.should == "#callout_required_title_CO1-1"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@id").text.should == "co_required_title_CO1-1"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/img/@src").text.should == "callouts/1.png"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/img/@alt").text.should == "1"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@href").text).to eq("#callout_required_title_CO1-1")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@id").text).to eq("co_required_title_CO1-1")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/img/@src").text).to eq("callouts/1.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/img/@alt").text).to eq("1")
 
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@href").text.should == "#callout_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@id").text.should == "co_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/img/@src").text.should == "callouts/2.png"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/img/@alt").text.should == "2"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@href").text).to eq("#callout_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@id").text).to eq("co_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/img/@alt").text).to eq("2")
 		end
 
 		it "should convert inline callouts in code with duplicate callouts in code with a calloutlist following" do
@@ -710,23 +710,23 @@ Hello THRICE <2>
 <1> First time.
 <2> Second time.
 "))
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@href").text.should == "#callout_required_title_CO1-1"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@id").text.should == "co_required_title_CO1-1"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/img/@src").text.should == "callouts/1.png"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/img/@alt").text.should == "1"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@href").text).to eq("#callout_required_title_CO1-1")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@id").text).to eq("co_required_title_CO1-1")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/img/@src").text).to eq("callouts/1.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/img/@alt").text).to eq("1")
 
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@href").text.should == "#callout_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@id").text.should == "co_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/img/@src").text.should == "callouts/2.png"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/img/@alt").text.should == "2"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@href").text).to eq("#callout_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@id").text).to eq("co_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/img/@alt").text).to eq("2")
 
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@href").text.should == "#callout_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@id").text.should == "co_required_title_CO1-3"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/img/@src").text.should == "callouts/2.png"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/img/@alt").text.should == "2"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@href").text).to eq("#callout_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@id").text).to eq("co_required_title_CO1-3")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/img/@alt").text).to eq("2")
 			end
 
 		it "should convert inline callouts in code with callouts out of order with a calloutlist following" do
@@ -745,29 +745,29 @@ What's in my head <1>
 <3> I wake up in the morning
 <4> and I step outside...
 "))
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@href").text.should == "#callout_required_title_CO1-4"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@id").text.should == "co_required_title_CO1-1"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/img/@src").text.should == "callouts/4.png"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/img/@alt").text.should == "4"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@href").text).to eq("#callout_required_title_CO1-4")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@id").text).to eq("co_required_title_CO1-1")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/img/@src").text).to eq("callouts/4.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/img/@alt").text).to eq("4")
 
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@href").text.should == "#callout_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@id").text.should == "co_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/img/@src").text.should == "callouts/2.png"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/img/@alt").text.should == "2"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@href").text).to eq("#callout_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@id").text).to eq("co_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/img/@alt").text).to eq("2")
 
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@href").text.should == "#callout_required_title_CO1-3"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@id").text.should == "co_required_title_CO1-3"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/img/@src").text.should == "callouts/3.png"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/img/@alt").text.should == "3"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@href").text).to eq("#callout_required_title_CO1-3")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@id").text).to eq("co_required_title_CO1-3")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/img/@src").text).to eq("callouts/3.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/img/@alt").text).to eq("3")
 
-			html.xpath("//pre[@data-type='programlisting']/a[4]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[4]/@href").text.should == "#callout_required_title_CO1-1"
-			html.xpath("//pre[@data-type='programlisting']/a[4]/@id").text.should == "co_required_title_CO1-4"
-			html.xpath("//pre[@data-type='programlisting']/a[4]/img/@src").text.should == "callouts/1.png"
-			html.xpath("//pre[@data-type='programlisting']/a[4]/img/@alt").text.should == "1"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/@href").text).to eq("#callout_required_title_CO1-1")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/@id").text).to eq("co_required_title_CO1-4")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/img/@src").text).to eq("callouts/1.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/img/@alt").text).to eq("1")
 			end
 
 		it "should convert inline callouts in code with duplicate callouts with callouts out of order with a calloutlist following" do
@@ -785,29 +785,29 @@ What's in my head <1>
 <2> A little peculiar.
 <3> I wake up in the morning
 "))
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@href").text.should == "#callout_required_title_CO1-3"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@id").text.should == "co_required_title_CO1-1"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/img/@src").text.should == "callouts/3.png"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/img/@alt").text.should == "3"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@href").text).to eq("#callout_required_title_CO1-3")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@id").text).to eq("co_required_title_CO1-1")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/img/@src").text).to eq("callouts/3.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/img/@alt").text).to eq("3")
 
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@href").text.should == "#callout_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@id").text.should == "co_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/img/@src").text.should == "callouts/2.png"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/img/@alt").text.should == "2"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@href").text).to eq("#callout_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@id").text).to eq("co_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/img/@alt").text).to eq("2")
 
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@href").text.should == "#callout_required_title_CO1-3"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@id").text.should == "co_required_title_CO1-3"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/img/@src").text.should == "callouts/3.png"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/img/@alt").text.should == "3"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@href").text).to eq("#callout_required_title_CO1-3")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@id").text).to eq("co_required_title_CO1-3")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/img/@src").text).to eq("callouts/3.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/img/@alt").text).to eq("3")
 
-			html.xpath("//pre[@data-type='programlisting']/a[4]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[4]/@href").text.should == "#callout_required_title_CO1-1"
-			html.xpath("//pre[@data-type='programlisting']/a[4]/@id").text.should == "co_required_title_CO1-4"
-			html.xpath("//pre[@data-type='programlisting']/a[4]/img/@src").text.should == "callouts/1.png"
-			html.xpath("//pre[@data-type='programlisting']/a[4]/img/@alt").text.should == "1"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/@href").text).to eq("#callout_required_title_CO1-1")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/@id").text).to eq("co_required_title_CO1-4")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/img/@src").text).to eq("callouts/1.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/img/@alt").text).to eq("1")
 			end
 
 		it "should convert inline callouts in code with a calloutlist following, when a callout in the code refers to a calloutlist number that does not exist" do
@@ -824,23 +824,23 @@ nm nm, just pointing to an item that doesn't exist <3>
 <1> I'm a dude
 <2> He's a dude.
 ")) 
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@href").text.should == "#callout_required_title_CO1-1"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@id").text.should == "co_required_title_CO1-1"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/img/@src").text.should == "callouts/1.png"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/img/@alt").text.should == "1"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@href").text).to eq("#callout_required_title_CO1-1")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@id").text).to eq("co_required_title_CO1-1")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/img/@src").text).to eq("callouts/1.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/img/@alt").text).to eq("1")
 
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@href").text.should == "#callout_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@id").text.should == "co_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/img/@src").text.should == "callouts/2.png"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/img/@alt").text.should == "2"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@href").text).to eq("#callout_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@id").text).to eq("co_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/img/@alt").text).to eq("2")
 
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@href").text.should == "#callout_required_title_CO1-3"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@id").text.should == "co_required_title_CO1-3"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/img/@src").text.should == "callouts/3.png"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/img/@alt").text.should == "3"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@href").text).to eq("#callout_required_title_CO1-3")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@id").text).to eq("co_required_title_CO1-3")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/img/@src").text).to eq("callouts/3.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/img/@alt").text).to eq("3")
 			end
 
 	it "should convert inline callouts in code without a calloutlist following"  do
@@ -855,29 +855,29 @@ That choco fudge folded in is totes yum. <4>
 ----
 
 "))
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@href").text.should == "#callout_required_title_CO1-1"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/@id").text.should == "co_required_title_CO1-1"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/img/@src").text.should == "callouts/1.png"
-			html.xpath("//pre[@data-type='programlisting']/a[1]/img/@alt").text.should == "1"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@href").text).to eq("#callout_required_title_CO1-1")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/@id").text).to eq("co_required_title_CO1-1")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/img/@src").text).to eq("callouts/1.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[1]/img/@alt").text).to eq("1")
 
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@href").text.should == "#callout_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/@id").text.should == "co_required_title_CO1-2"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/img/@src").text.should == "callouts/2.png"
-			html.xpath("//pre[@data-type='programlisting']/a[2]/img/@alt").text.should == "2"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@href").text).to eq("#callout_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/@id").text).to eq("co_required_title_CO1-2")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/img/@src").text).to eq("callouts/2.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[2]/img/@alt").text).to eq("2")
 
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@href").text.should == "#callout_required_title_CO1-3"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/@id").text.should == "co_required_title_CO1-3"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/img/@src").text.should == "callouts/3.png"
-			html.xpath("//pre[@data-type='programlisting']/a[3]/img/@alt").text.should == "3"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@href").text).to eq("#callout_required_title_CO1-3")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/@id").text).to eq("co_required_title_CO1-3")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/img/@src").text).to eq("callouts/3.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[3]/img/@alt").text).to eq("3")
 			
-			html.xpath("//pre[@data-type='programlisting']/a[4]/@class").text.should == "co"
-			html.xpath("//pre[@data-type='programlisting']/a[4]/@href").text.should == "#callout_required_title_CO1-4"
-			html.xpath("//pre[@data-type='programlisting']/a[4]/@id").text.should == "co_required_title_CO1-4"
-			html.xpath("//pre[@data-type='programlisting']/a[4]/img/@src").text.should == "callouts/4.png"
-			html.xpath("//pre[@data-type='programlisting']/a[4]/img/@alt").text.should == "4"
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/@class").text).to eq("co")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/@href").text).to eq("#callout_required_title_CO1-4")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/@id").text).to eq("co_required_title_CO1-4")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/img/@src").text).to eq("callouts/4.png")
+			expect(html.xpath("//pre[@data-type='programlisting']/a[4]/img/@alt").text).to eq("4")
 		end
 
 
@@ -893,10 +893,10 @@ That choco fudge folded in is totes yum. <4>
 # "))
 # 		html.xpath("//pre[@data-type='programlisting']/text()").text.should == "Roses are red, 
 #    Violets are blue. "
-#    		html.xpath("//pre[@data-type='programlisting']/a[1]").text.should == "(1)"
-#    		html.xpath("//pre[@data-type='programlisting']/b[2]").text.should == "(2)"
-#    		html.xpath("//ol[@class='calloutlist']/li[1]/p").text.should == "➊ This is a fact."
-#    		html.xpath("//ol[@class='calloutlist']/li[2]/p").text.should == "➋ This poem uses the literary device known as a surprise ending."
+#    		expect(html.xpath("//pre[@data-type='programlisting']/a[1]").text).to eq("(1)")
+#    		expect(html.xpath("//pre[@data-type='programlisting']/b[2]").text).to eq("(2)")
+#    		expect(html.xpath("//ol[@class='calloutlist']/li[1]/p").text).to eq("➊ This is a fact.")
+#    		expect(html.xpath("//ol[@class='calloutlist']/li[2]/p").text).to eq("➋ This poem uses the literary device known as a surprise ending.")
 # 	end
 
 	# Tests inline_footnote template
@@ -908,198 +908,198 @@ A second footnote with a reference ID.footnoteref:[note2,Second footnote.]
 
 Finally a reference to the second footnote.footnoteref:[note2]
 "))
-		html.xpath("//p[1]/span[@data-type='footnote']").text.should == "An example footnote."
+		expect(html.xpath("//p[1]/span[@data-type='footnote']").text).to eq("An example footnote.")
 		html.xpath("//p[1]/span[@data-type='footnote']/@id").size.should == 0
-		html.xpath("//p[2]/span[@data-type='footnote']").text.should == "Second footnote."
-		html.xpath("//p[2]/span[@data-type='footnote']/@id").text.should == "note2"
+		expect(html.xpath("//p[2]/span[@data-type='footnote']").text).to eq("Second footnote.")
+		expect(html.xpath("//p[2]/span[@data-type='footnote']/@id").text).to eq("note2")
 		html.xpath("//p[3]/a[@data-type='footnoteref']/text()").size.should == 0
-		html.xpath("//p[3]/a[@data-type='footnoteref']/@href").text.should == "#note2"
+		expect(html.xpath("//p[3]/a[@data-type='footnoteref']/@href").text).to eq("#note2")
 	end
 
 	# Tests inline_image template
 	it "should convert inline images" do
 		html = Nokogiri::HTML(convert("Here is an inline figure: image:images/logo.png[]"))
-		html.xpath("//p/img/@src").text.should == "images/logo.png"
+		expect(html.xpath("//p/img/@src").text).to eq("images/logo.png")
 	end
 
 	# Tests inline_quoted template
 	it "should convert inline formatting" do
 		html = Nokogiri::HTML(convert("This para has __emphasis__, *bold**, ++literal++, ^superscript^, ~subscript~, __++replaceable++__, and *+userinput+*."))
-		html.xpath("//p/em[1]").text.should == "emphasis"
-		html.xpath("//p/strong[1]").text.should == "bold"
-		html.xpath("//p/code[1]").text.should == "literal"
-		html.xpath("//p/sup").text.should == "superscript"
-		html.xpath("//p/sub").text.should == "subscript"
-		html.xpath("//p/em/code").text.should == "replaceable"
-		html.xpath("//p/strong/code").text.should == "userinput"
+		expect(html.xpath("//p/em[1]").text).to eq("emphasis")
+		expect(html.xpath("//p/strong[1]").text).to eq("bold")
+		expect(html.xpath("//p/code[1]").text).to eq("literal")
+		expect(html.xpath("//p/sup").text).to eq("superscript")
+		expect(html.xpath("//p/sub").text).to eq("subscript")
+		expect(html.xpath("//p/em/code").text).to eq("replaceable")
+		expect(html.xpath("//p/strong/code").text).to eq("userinput")
 	end
 
 	# Tests math in inline_quoted template
 	it "should convert inline latexmath equations with dollar sign delimeters to use standard delimiters" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is latexmath:[$a^2 + b^2 = c^2$]"))
-		html.xpath("//p/span[@data-type='tex']").text.should == "\\(a^2 + b^2 = c^2\\)"
+		expect(html.xpath("//p/span[@data-type='tex']").text).to eq("\\(a^2 + b^2 = c^2\\)")
 	end
 	it "should convert inline latexmath equations with standard delimiters with no change" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is latexmath:[\\(a^2 + b^2 = c^2\\)]"))
-		html.xpath("//p/span[@data-type='tex']").text.should == "\\(a^2 + b^2 = c^2\\)"
+		expect(html.xpath("//p/span[@data-type='tex']").text).to eq("\\(a^2 + b^2 = c^2\\)")
 	end
 	it "should convert inline latexmath equations with no delimiters and add delimiters" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is latexmath:[a^2 + b^2 = c^2]"))
-		html.xpath("//p/span[@data-type='tex']").text.should == "\\(a^2 + b^2 = c^2\\)"
+		expect(html.xpath("//p/span[@data-type='tex']").text).to eq("\\(a^2 + b^2 = c^2\\)")
 	end
 	it "should convert inline asciimath equations with dollar sign delimeters with no change" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is asciimath:[\$a^2 + b^2 = c^2\$]"))
-		html.xpath("//p/span[@data-type='tex']").text.should == "\$a^2 + b^2 = c^2\$"
+		expect(html.xpath("//p/span[@data-type='tex']").text).to eq("\$a^2 + b^2 = c^2\$")
 	end
 	it "should convert inline asciimath equations with no delimeters and add delimiters" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is asciimath:[a^2 + b^2 = c^2]"))
-		html.xpath("//p/span[@data-type='tex']").text.should == "\$a^2 + b^2 = c^2\$"
+		expect(html.xpath("//p/span[@data-type='tex']").text).to eq("\$a^2 + b^2 = c^2\$")
 	end
 
 	# Tests inline_indexterm template - source markup is in files/indexterm_testing.asciidoc
 	it "should convert inline indexterms with one term" do
 		html = Nokogiri::HTML(convert_indexterm_tests)
 		# Primary only, with quation marks
-		html.xpath("//section[@data-type='sect1'][1]/section[@data-type='sect2'][1]/p[1]/a/@data-type").text.should == "indexterm"
-		html.xpath("//section[@data-type='sect1'][1]/section[@data-type='sect2'][1]/p[1]/a/@data-primary").text.should == "metaclass"
+		expect(html.xpath("//section[@data-type='sect1'][1]/section[@data-type='sect2'][1]/p[1]/a/@data-type").text).to eq("indexterm")
+		expect(html.xpath("//section[@data-type='sect1'][1]/section[@data-type='sect2'][1]/p[1]/a/@data-primary").text).to eq("metaclass")
 		# Primary only, without quotation marks
-		html.xpath("//section[@data-type='sect1'][1]/section[@data-type='sect2'][1]/p[2]/a/@data-type").text.should == "indexterm"
-		html.xpath("//section[@data-type='sect1'][1]/section[@data-type='sect2'][1]/p[2]/a/@data-primary").text.should == "accessibility"
+		expect(html.xpath("//section[@data-type='sect1'][1]/section[@data-type='sect2'][1]/p[2]/a/@data-type").text).to eq("indexterm")
+		expect(html.xpath("//section[@data-type='sect1'][1]/section[@data-type='sect2'][1]/p[2]/a/@data-primary").text).to eq("accessibility")
 	end
 
 	it "should convert inline indexterms with two terms" do
 		html = Nokogiri::HTML(convert_indexterm_tests)
 		# Primary only
-		html.xpath("//section[@data-type='sect1'][2]/section[@data-type='sect2'][1]/p[1]/a/@data-see").text.should == "aspect-oriented"
-		html.xpath("//section[@data-type='sect1'][2]/section[@data-type='sect2'][1]/p[2]/a/@data-seealso").text.should == "namespace"
-		html.xpath("//section[@data-type='sect1'][2]/section[@data-type='sect2'][1]/p[3]/a/@data-primary-sortas").text.should == "patterns"
-		html.xpath("//section[@data-type='sect1'][2]/section[@data-type='sect2'][1]/p[4]/a/@id").text.should == "dynamic"
-		html.xpath("//section[@data-type='sect1'][2]/section[@data-type='sect2'][1]/p[5]/a/@data-startref").text.should == "dynamic"
+		expect(html.xpath("//section[@data-type='sect1'][2]/section[@data-type='sect2'][1]/p[1]/a/@data-see").text).to eq("aspect-oriented")
+		expect(html.xpath("//section[@data-type='sect1'][2]/section[@data-type='sect2'][1]/p[2]/a/@data-seealso").text).to eq("namespace")
+		expect(html.xpath("//section[@data-type='sect1'][2]/section[@data-type='sect2'][1]/p[3]/a/@data-primary-sortas").text).to eq("patterns")
+		expect(html.xpath("//section[@data-type='sect1'][2]/section[@data-type='sect2'][1]/p[4]/a/@id").text).to eq("dynamic")
+		expect(html.xpath("//section[@data-type='sect1'][2]/section[@data-type='sect2'][1]/p[5]/a/@data-startref").text).to eq("dynamic")
 		# Secondary
-		html.xpath("//section[@data-type='sect1'][2]/section[@data-type='sect2'][2]/p[1]/a/@data-secondary").text.should == "eigenclass"
+		expect(html.xpath("//section[@data-type='sect1'][2]/section[@data-type='sect2'][2]/p[1]/a/@data-secondary").text).to eq("eigenclass")
 	end
 
 	it "should convert inline indexterms with three terms" do
 		html = Nokogiri::HTML(convert_indexterm_tests)
 		# Primary only
-		html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][1]/p[1]/a/@id").text.should == "orthogonality"
-		html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][1]/p[2]/a/@data-see").text.should == "destructor"
-		html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][1]/p[2]/a/@data-seealso").text.should == "factory method"
+		expect(html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][1]/p[1]/a/@id").text).to eq("orthogonality")
+		expect(html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][1]/p[2]/a/@data-see").text).to eq("destructor")
+		expect(html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][1]/p[2]/a/@data-seealso").text).to eq("factory method")
 		# Secondary
-		html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][2]/p[1]/a/@data-secondary").text.should == "immutable"
-		html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][2]/p[1]/a/@data-see").text.should == "instance method"
-		html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][2]/p[2]/a/@data-seealso").text.should == "partial class"
-		html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][2]/p[3]/a/@data-secondary-sortas").text.should == "iterator"
+		expect(html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][2]/p[1]/a/@data-secondary").text).to eq("immutable")
+		expect(html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][2]/p[1]/a/@data-see").text).to eq("instance method")
+		expect(html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][2]/p[2]/a/@data-seealso").text).to eq("partial class")
+		expect(html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][2]/p[3]/a/@data-secondary-sortas").text).to eq("iterator")
 		# Tertiary, with quotation marks
-		html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][3]/p[1]/a/@data-secondary").text.should == "virtual class"
-		html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][3]/p[1]/a/@data-tertiary").text.should == "subtype"
+		expect(html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][3]/p[1]/a/@data-secondary").text).to eq("virtual class")
+		expect(html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][3]/p[1]/a/@data-tertiary").text).to eq("subtype")
 		# Tertiary, without quotation marks
-		html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][3]/p[2]/a/@data-secondary").text.should == "test-driven development"
-		html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][3]/p[2]/a/@data-tertiary").text.should == "weak reference"		
+		expect(html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][3]/p[2]/a/@data-secondary").text).to eq("test-driven development")
+		expect(html.xpath("//section[@data-type='sect1'][3]/section[@data-type='sect2'][3]/p[2]/a/@data-tertiary").text).to eq("weak reference")		
 	end
 
 	it "should convert inline indexterms with four terms" do
 		html = Nokogiri::HTML(convert_indexterm_tests)
 		# Primary only
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][1]/p[1]/a/@id").text.should == "slicing"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][1]/p[1]/a/@data-see").text.should == "access control"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][1]/p[2]/a/@data-seealso").text.should == "hybrid"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][1]/p[3]/a/@data-primary-sortas").text.should == "uninitialized"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][1]/p[4]/a/@data-see").text.should == "mutator method"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][1]/p[4]/a/@data-seealso").text.should == "policy-based design"
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][1]/p[1]/a/@id").text).to eq("slicing")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][1]/p[1]/a/@data-see").text).to eq("access control")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][1]/p[2]/a/@data-seealso").text).to eq("hybrid")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][1]/p[3]/a/@data-primary-sortas").text).to eq("uninitialized")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][1]/p[4]/a/@data-see").text).to eq("mutator method")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][1]/p[4]/a/@data-seealso").text).to eq("policy-based design")
 		# Secondary
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][2]/p[1]/a/@data-secondary").text.should == "viscosity"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][2]/p[1]/a/@id").text.should == "encapsulation"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][2]/p[2]/a/@data-secondary").text.should == "superclass"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][2]/p[2]/a/@data-see").text.should == "typecasting"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][2]/p[2]/a/@data-seealso").text.should == "virtual inheritance"
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][2]/p[1]/a/@data-secondary").text).to eq("viscosity")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][2]/p[1]/a/@id").text).to eq("encapsulation")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][2]/p[2]/a/@data-secondary").text).to eq("superclass")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][2]/p[2]/a/@data-see").text).to eq("typecasting")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][2]/p[2]/a/@data-seealso").text).to eq("virtual inheritance")
 		# Tertiary
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[1]/a/@data-secondary").text.should == "shadowed name"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[1]/a/@data-tertiary").text.should == "function"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[1]/a/@data-see").text.should == "late binding"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[2]/a/@data-secondary").text.should == "array"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[2]/a/@data-tertiary").text.should == "compiler"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[2]/a/@data-seealso").text.should == "subroutine"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[3]/a/@data-secondary").text.should == "stack"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[3]/a/@data-tertiary").text.should == "paradigm"
-		html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[3]/a/@data-tertiary-sortas").text.should == "enumerable"
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[1]/a/@data-secondary").text).to eq("shadowed name")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[1]/a/@data-tertiary").text).to eq("function")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[1]/a/@data-see").text).to eq("late binding")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[2]/a/@data-secondary").text).to eq("array")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[2]/a/@data-tertiary").text).to eq("compiler")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[2]/a/@data-seealso").text).to eq("subroutine")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[3]/a/@data-secondary").text).to eq("stack")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[3]/a/@data-tertiary").text).to eq("paradigm")
+		expect(html.xpath("//section[@data-type='sect1'][4]/section[@data-type='sect2'][3]/p[3]/a/@data-tertiary-sortas").text).to eq("enumerable")
 	end
 
 	it "should convert inline indexterms with five terms" do
 		html = Nokogiri::HTML(convert_indexterm_tests)
 		# Primary only
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][1]/p[1]/a/@id").text.should == "mapping"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][1]/p[1]/a/@data-see").text.should == "overload"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][1]/p[1]/a/@data-seealso").text.should == "parse"
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][1]/p[1]/a/@id").text).to eq("mapping")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][1]/p[1]/a/@data-see").text).to eq("overload")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][1]/p[1]/a/@data-seealso").text).to eq("parse")
 		# Secondary
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[1]/a/@data-secondary").text.should == "token"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[1]/a/@id").text.should == "syntax"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[1]/a/@data-see").text.should == "binary"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[2]/a/@data-secondary").text.should == "conditional"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[2]/a/@id").text.should == "collection"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[2]/a/@data-seealso").text.should == "alias"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[3]/a/@data-secondary").text.should == "operation"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[3]/a/@id").text.should == "semantics"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[3]/a/@data-secondary-sortas").text.should == "parameter"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[4]/a/@data-secondary").text.should == "abstraction"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[4]/a/@id").text.should == "constant"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[4]/a/@data-see").text.should == "arithmetic operator"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[4]/a/@data-seealso").text.should == "base type"
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[1]/a/@data-secondary").text).to eq("token")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[1]/a/@id").text).to eq("syntax")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[1]/a/@data-see").text).to eq("binary")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[2]/a/@data-secondary").text).to eq("conditional")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[2]/a/@id").text).to eq("collection")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[2]/a/@data-seealso").text).to eq("alias")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[3]/a/@data-secondary").text).to eq("operation")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[3]/a/@id").text).to eq("semantics")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[3]/a/@data-secondary-sortas").text).to eq("parameter")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[4]/a/@data-secondary").text).to eq("abstraction")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[4]/a/@id").text).to eq("constant")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[4]/a/@data-see").text).to eq("arithmetic operator")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][2]/p[4]/a/@data-seealso").text).to eq("base type")
 		# Tertiary
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[1]/a/@data-secondary").text.should == "deprecated"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[1]/a/@data-tertiary").text.should == "finalization"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[1]/a/@id").text.should == "little-endian"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[2]/a/@data-secondary").text.should == "parallel"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[2]/a/@data-tertiary").text.should == "scheme"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[2]/a/@data-see").text.should == "ternary"
-		html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[2]/a/@data-seealso").text.should == "exception"
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[1]/a/@data-secondary").text).to eq("deprecated")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[1]/a/@data-tertiary").text).to eq("finalization")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[1]/a/@id").text).to eq("little-endian")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[2]/a/@data-secondary").text).to eq("parallel")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[2]/a/@data-tertiary").text).to eq("scheme")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[2]/a/@data-see").text).to eq("ternary")
+		expect(html.xpath("//section[@data-type='sect1'][5]/section[@data-type='sect2'][3]/p[2]/a/@data-seealso").text).to eq("exception")
 	end
 
 	it "should convert inline indexterms with six terms" do
 		html = Nokogiri::HTML(convert_indexterm_tests)
 		# Secondary
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][1]/p[1]/a/@data-secondary").text.should == "while loop"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][1]/p[1]/a/@id").text.should == "retro"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][1]/p[1]/a/@data-see").text.should == "top-level class"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][1]/p[1]/a/@data-seealso").text.should == "unary"
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][1]/p[1]/a/@data-secondary").text).to eq("while loop")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][1]/p[1]/a/@id").text).to eq("retro")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][1]/p[1]/a/@data-see").text).to eq("top-level class")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][1]/p[1]/a/@data-seealso").text).to eq("unary")
 		# Tertiary
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[1]/a/@data-secondary").text.should == "precedence"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[1]/a/@data-tertiary").text.should == "overriding"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[1]/a/@id").text.should == "lightweight"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[1]/a/@data-see").text.should == "infinite"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[2]/a/@data-secondary").text.should == "encapsulation"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[2]/a/@data-tertiary").text.should == "condition"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[2]/a/@id").text.should == "aggregation"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[2]/a/@data-seealso").text.should == "boundary"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[3]/a/@data-secondary").text.should == "classpath"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[3]/a/@data-tertiary").text.should == "import"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[3]/a/@id").text.should == "datagram"
-		html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[3]/a/@data-tertiary-sortas").text.should == "method"
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[1]/a/@data-secondary").text).to eq("precedence")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[1]/a/@data-tertiary").text).to eq("overriding")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[1]/a/@id").text).to eq("lightweight")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[1]/a/@data-see").text).to eq("infinite")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[2]/a/@data-secondary").text).to eq("encapsulation")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[2]/a/@data-tertiary").text).to eq("condition")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[2]/a/@id").text).to eq("aggregation")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[2]/a/@data-seealso").text).to eq("boundary")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[3]/a/@data-secondary").text).to eq("classpath")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[3]/a/@data-tertiary").text).to eq("import")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[3]/a/@id").text).to eq("datagram")
+		expect(html.xpath("//section[@data-type='sect1'][6]/section[@data-type='sect2'][2]/p[3]/a/@data-tertiary-sortas").text).to eq("method")
 	end
 
 	it "should convert inline indexterms with seven terms" do
 		html = Nokogiri::HTML(convert_indexterm_tests)
 		# Tertiary
-		html.xpath("//section[@data-type='sect1'][7]/p[1]/a/@data-secondary").text.should == "public"
-		html.xpath("//section[@data-type='sect1'][7]/p[1]/a/@data-tertiary").text.should == "relational"
-		html.xpath("//section[@data-type='sect1'][7]/p[1]/a/@id").text.should == "cascaded"
-		html.xpath("//section[@data-type='sect1'][7]/p[1]/a/@data-see").text.should == "inline"
-		html.xpath("//section[@data-type='sect1'][7]/p[1]/a/@data-seealso").text.should == "private"
+		expect(html.xpath("//section[@data-type='sect1'][7]/p[1]/a/@data-secondary").text).to eq("public")
+		expect(html.xpath("//section[@data-type='sect1'][7]/p[1]/a/@data-tertiary").text).to eq("relational")
+		expect(html.xpath("//section[@data-type='sect1'][7]/p[1]/a/@id").text).to eq("cascaded")
+		expect(html.xpath("//section[@data-type='sect1'][7]/p[1]/a/@data-see").text).to eq("inline")
+		expect(html.xpath("//section[@data-type='sect1'][7]/p[1]/a/@data-seealso").text).to eq("private")
 	end
 
 	it "should convert inline indexterm next-gen sortas attributes properly (primary-sortas, secondary-sortas, tertiary-sortas)" do
 		html = Nokogiri::HTML(convert_indexterm_tests)
-		html.xpath("//section[@id='sortas_tests']/p[1]/a/@data-primary-sortas").text.should == "one"
-		html.xpath("//section[@id='sortas_tests']/p[1]/a/@data-secondary-sortas").text.should == "two"
-		html.xpath("//section[@id='sortas_tests']/p[1]/a/@data-tertiary-sortas").text.should == "three"
+		expect(html.xpath("//section[@id='sortas_tests']/p[1]/a/@data-primary-sortas").text).to eq("one")
+		expect(html.xpath("//section[@id='sortas_tests']/p[1]/a/@data-secondary-sortas").text).to eq("two")
+		expect(html.xpath("//section[@id='sortas_tests']/p[1]/a/@data-tertiary-sortas").text).to eq("three")
 	end
 
         it "should ignore legacy sortas when primary, secondary, or tertiary sortas are present" do
                html = Nokogiri::HTML(convert_indexterm_tests)
                html.xpath("//section[@id='sortas_tests']/p[position() > 1]/a/@*[contains(., 'ignoreme')]").length.should == 0
-               html.xpath("//section[@id='sortas_tests']/p[2]/a/@data-primary-sortas").text.should == "one"
-               html.xpath("//section[@id='sortas_tests']/p[3]/a/@data-secondary-sortas").text.should == "two"
-               html.xpath("//section[@id='sortas_tests']/p[4]/a/@data-tertiary-sortas").text.should == "three"
+               expect(html.xpath("//section[@id='sortas_tests']/p[2]/a/@data-primary-sortas").text).to eq("one")
+               expect(html.xpath("//section[@id='sortas_tests']/p[3]/a/@data-secondary-sortas").text).to eq("two")
+               expect(html.xpath("//section[@id='sortas_tests']/p[4]/a/@data-tertiary-sortas").text).to eq("three")
         end
 
         it "should ignore badly formed indexterms" do 
@@ -1119,39 +1119,39 @@ Finally a reference to the second footnote.footnoteref:[note2]
 
 	# it "should convert inline DocBook passthroughs to HTMLBook" do
 	# 	html = Nokogiri::HTML(convert_passthrough_tests)
-	# 	html.xpath("//section[@data-type='sect1'][1]/p[1]/span[@class='keep-together']").text.should == "DocBook phrase element"
-	# 	html.xpath("//section[@data-type='sect1'][1]/p[2]/code").text.should == "DocBook code element"
+	# 	expect(html.xpath("//section[@data-type='sect1'][1]/p[1]/span[@class='keep-together']").text).to eq("DocBook phrase element")
+	# 	expect(html.xpath("//section[@data-type='sect1'][1]/p[2]/code").text).to eq("DocBook code element")
 	# end
 
 	# it "should convert block DocBook passthroughs to HTMLBook" do
 	# 	html = Nokogiri::HTML(convert_passthrough_tests)
-	# 	html.xpath("//section[@data-type='sect1'][2]/pre[@data-type='programlisting']/strong/code").text.should == "first line of code here"
-	# 	html.xpath("//section[@data-type='sect1'][2]/figure/figcaption").text.should == "DocBook Figure Markup"
-	# 	html.xpath("//section[@data-type='sect1'][2]/figure/img/@src").text.should == "images/docbook.png"
-	# 	html.xpath("//section[@data-type='sect1'][2]/blockquote/p[@data-type='attribution']").text.should == "Lewis Carroll"
+	# 	expect(html.xpath("//section[@data-type='sect1'][2]/pre[@data-type='programlisting']/strong/code").text).to eq("first line of code here")
+	# 	expect(html.xpath("//section[@data-type='sect1'][2]/figure/figcaption").text).to eq("DocBook Figure Markup")
+	# 	expect(html.xpath("//section[@data-type='sect1'][2]/figure/img/@src").text).to eq("images/docbook.png")
+	# 	expect(html.xpath("//section[@data-type='sect1'][2]/blockquote/p[@data-type='attribution']").text).to eq("Lewis Carroll")
 	# 	html.xpath("//section[@data-type='sect1'][2]/blockquote/p").text.should start_with "Alice was beginning to get very tired"
 	# end
 
 	# it "should not convert inline HTML block passthroughs" do
 	# 	html = Nokogiri::HTML(convert_passthrough_tests)
-	# 	html.xpath("//section[@data-type='sect1'][3]/p[1]/strong").text.should == "HTML strong element"
-	# 	html.xpath("//section[@data-type='sect1'][3]/p[2]/code").text.should == "HTML code element"
+	# 	expect(html.xpath("//section[@data-type='sect1'][3]/p[1]/strong").text).to eq("HTML strong element")
+	# 	expect(html.xpath("//section[@data-type='sect1'][3]/p[2]/code").text).to eq("HTML code element")
 	# end
 
 	# it "should not convert block HTML passthroughs" do
 	# 	html = Nokogiri::HTML(convert_passthrough_tests)
-	# 	html.xpath("//section[@data-type='sect1'][4]/p[2]").text.should == "Some text in an HTML p element."
-	# 	html.xpath("//section[@data-type='sect1'][4]/figure/figcaption").text.should == "HTML Figure Markup"
-	# 	html.xpath("//section[@data-type='sect1'][4]/figure/img/@src").text.should == "images/html.png"
+	# 	expect(html.xpath("//section[@data-type='sect1'][4]/p[2]").text).to eq("Some text in an HTML p element.")
+	# 	expect(html.xpath("//section[@data-type='sect1'][4]/figure/figcaption").text).to eq("HTML Figure Markup")
+	# 	expect(html.xpath("//section[@data-type='sect1'][4]/figure/img/@src").text).to eq("images/html.png")
 	# 	html.xpath("//section[@data-type='sect1'][4]/blockquote/p").text.should start_with "So she was considering in her own mind"
 	# end
 
 	# it "should ignore processing instruction passthroughs" do
 	# 	html = Nokogiri::HTML(convert_passthrough_tests)
-	# 	html.xpath("//section[@data-type='sect1'][5]/p[1]").text.should == "Processing instruction in inline passthroughs should be ignored entirely."
-	# 	html.xpath("//section[@data-type='sect1'][5]/p[2]/span").text.should == "should be subbed out."
+	# 	expect(html.xpath("//section[@data-type='sect1'][5]/p[1]").text).to eq("Processing instruction in inline passthroughs should be ignored entirely.")
+	# 	expect(html.xpath("//section[@data-type='sect1'][5]/p[2]/span").text).to eq("should be subbed out.")
 	# 	html.xpath("//section[@data-type='sect1'][5]").text.should_not include '<?hard-pagebreak?>'
-	# 	html.xpath("//section[@data-type='sect1'][5]/p[5]").text.should == "text before  text after"
+	# 	expect(html.xpath("//section[@data-type='sect1'][5]/p[5]").text).to eq("text before  text after")
 	# end
 
 end


### PR DESCRIPTION
While I was testing this locally, I noticed that there was still Ruby 2.x era syntax in the scripts and spec files. I went ahead and updated those and also set the Ruby version in the Gemfile to match what's on the Workers.