### PR TITLE
TOOLSDEV-385: Also Add translate="no" to Block Literals

### DIFF
--- a/htmlbook/block_literal.html.erb
+++ b/htmlbook/block_literal.html.erb
@@ -1,1 +1,1 @@
-<%#encoding:UTF-8%><pre><%= content %></pre>
+<%#encoding:UTF-8%><pre translate="no"><%= content %></pre>

--- a/spec/htmlbook_spec.rb
+++ b/spec/htmlbook_spec.rb
@@ -303,6 +303,16 @@ This is a literal block.
 		html = Nokogiri::HTML(convert(" This is also a literal block."))
 		html.xpath("//pre").text.should == "This is also a literal block."
 	end
+	
+	it "should add translate='no' attribute to literal blocks" do
+		html = Nokogiri::HTML(convert("
+....
+This is text in a literal block
+that should not be translated.
+....
+"))
+		html.xpath("//pre/@translate").text.should == "no"
+	end
 
 	# Test block_math template
 	it "should convert math blocks" do


### PR DESCRIPTION
Found this while testing on Staging. Block literals are delimited by `....` in Asciidoc. Semantically they are used for pre-formatted text that is not necessarily code (which are block listings in Asciidoc parlance). In practice they both end up as `<pre>` elements and neither should be machine translated.