### PR TITLE
Revert toolsdev 434

### DIFF
--- a/htmlbook/inline_quoted.html.erb
+++ b/htmlbook/inline_quoted.html.erb
@@ -10,8 +10,8 @@ when :double %><%= class_attr ? %(<span#{class_attr}>&#8220;#{@text}&#8221;</spa
 when :single %><%= class_attr ? %(<span#{class_attr}>&#8216;#{@text}&#8217;</span>) : %(&#8216;#{@text}&#8217;) %><%
 when :latexmath
   open, close = ::Asciidoctor::INLINE_MATH_DELIMITERS[@type] %><% 
-  if (@text.start_with? '\(') && (@text.end_with? '\)') %><%= %(<span data-type="tex">#{@text[2..-3]}</span>) %>
-  <% else %><%= %(<span data-type="tex">#{@text}</span>) %>
+  if (@text.start_with? '\(') && (@text.end_with? '\)') %><%= %(<span data-type="tex">#{@text}</span>) %>
+  <% else %><%= %(<span data-type="tex">#{open}#{@text}#{close}</span>) %>
   <% end %><%
 when :asciimath
   open, close = ::Asciidoctor::INLINE_MATH_DELIMITERS[@type] %><% 

--- a/spec/htmlbook_spec.rb
+++ b/spec/htmlbook_spec.rb
@@ -980,17 +980,17 @@ Finally a reference to the second footnote.footnoteref:[note2]
 	end
 
 	# Tests math in inline_quoted template
-	it "should convert inline latexmath equations with dollar sign delimeters to use no delimiters" do
+	it "should convert inline latexmath equations with dollar sign delimeters to use standard delimiters" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is latexmath:[$a^2 + b^2 = c^2$]"))
-		expect(html.xpath("//p/span[@data-type='tex']").text.should == "a^2 + b^2 = c^2")
+		expect(html.xpath("//p/span[@data-type='tex']").text).to eq("\\(a^2 + b^2 = c^2\\)")
 	end
-	it "should convert inline latexmath equations with standard delimiters removed" do
+	it "should convert inline latexmath equations with standard delimiters with no change" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is latexmath:[\\(a^2 + b^2 = c^2\\)]"))
-		expect(html.xpath("//p/span[@data-type='tex']").text.should == "a^2 + b^2 = c^2")
+		expect(html.xpath("//p/span[@data-type='tex']").text).to eq("\\(a^2 + b^2 = c^2\\)")
 	end
-	it "should convert inline latexmath equations with no delimiters without changing them" do
+	it "should convert inline latexmath equations with no delimiters and add delimiters" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is latexmath:[a^2 + b^2 = c^2]"))
-		expect(html.xpath("//p/span[@data-type='tex']").text.should == "a^2 + b^2 = c^2")
+		expect(html.xpath("//p/span[@data-type='tex']").text).to eq("\\(a^2 + b^2 = c^2\\)")
 	end
 	it "should convert inline asciimath equations with dollar sign delimeters with no change" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is asciimath:[\$a^2 + b^2 = c^2\$]"))

--- a/spec/htmlbook_spec.rb
+++ b/spec/htmlbook_spec.rb
@@ -982,15 +982,15 @@ Finally a reference to the second footnote.footnoteref:[note2]
 	# Tests math in inline_quoted template
 	it "should convert inline latexmath equations with dollar sign delimeters to use no delimiters" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is latexmath:[$a^2 + b^2 = c^2$]"))
-        expect(html.xpath("//p/span[@data-type='tex']").text).to eq("a^2 + b^2 = c^2")
+		expect(html.xpath("//p/span[@data-type='tex']").text.should == "a^2 + b^2 = c^2")
 	end
 	it "should convert inline latexmath equations with standard delimiters removed" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is latexmath:[\\(a^2 + b^2 = c^2\\)]"))
-        expect(html.xpath("//p/span[@data-type='tex']").text).to eq("a^2 + b^2 = c^2")
+		expect(html.xpath("//p/span[@data-type='tex']").text.should == "a^2 + b^2 = c^2")
 	end
 	it "should convert inline latexmath equations with no delimiters without changing them" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is latexmath:[a^2 + b^2 = c^2]"))
-        expect(html.xpath("//p/span[@data-type='tex']").text).to eq("a^2 + b^2 = c^2")
+		expect(html.xpath("//p/span[@data-type='tex']").text.should == "a^2 + b^2 = c^2")
 	end
 	it "should convert inline asciimath equations with dollar sign delimeters with no change" do
 		html = Nokogiri::HTML(convert("The Pythagorean Theorem is asciimath:[\$a^2 + b^2 = c^2\$]"))


### PR DESCRIPTION
@nadamsoreilly upon reflection/further research, I think we want to handle this in `latexmath`, because `\(x +y \)` _is_ valid markup, and so there's a world in which we get this in either an HTML book or in a passthrough, and so we shouldn't just be ripping these out for fun.